### PR TITLE
Add Columns and Cards migrations/models

### DIFF
--- a/app/Models/Card.php
+++ b/app/Models/Card.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/**
+ * @property int $id
+ * @property int $column_id
+ * @property string $title
+ * @property string $status
+ */
+class Card extends Model
+{
+    use HasFactory;
+
+    protected $table = 'cards';
+
+    protected $fillable = [
+        'column_id',
+        'title',
+        'status',
+    ];
+
+    /**
+     * Get the column that owns the card.
+     */
+    public function column(): BelongsTo
+    {
+        return $this->belongsTo(Column::class);
+    }
+}

--- a/app/Models/Column.php
+++ b/app/Models/Column.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+/**
+ * @property int $id
+ * @property int $year
+ * @property int $month
+ * @property int $user_id
+ */
+class Column extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'year',
+        'month',
+        'user_id',
+    ];
+
+    /**
+     * Get the user that owns the column.
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    /**
+     * Get the cards for the column.
+     */
+    public function cards(): HasMany
+    {
+        return $this->hasMany(Card::class);
+    }
+}

--- a/database/factories/CardFactory.php
+++ b/database/factories/CardFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Column;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\Card>
+ */
+class CardFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'column_id' => Column::factory(),
+            'title' => fake()->sentence(3),
+            'status' => fake()->randomElement(['not_started', 'in_progress', 'completed']),
+        ];
+    }
+}

--- a/database/factories/ColumnFactory.php
+++ b/database/factories/ColumnFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<\App\Models\Column>
+ */
+class ColumnFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'year' => fake()->year(),
+            'month' => fake()->numberBetween(1, 12),
+            'user_id' => User::factory(),
+        ];
+    }
+}

--- a/database/migrations/2025_06_13_000000_create_columns_table.php
+++ b/database/migrations/2025_06_13_000000_create_columns_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('columns', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('year');
+            $table->unsignedTinyInteger('month');
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('columns');
+    }
+};

--- a/database/migrations/2025_06_13_000001_create_cards_table.php
+++ b/database/migrations/2025_06_13_000001_create_cards_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('cards', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('column_id')->constrained('columns')->cascadeOnDelete();
+            $table->string('title');
+            $table->enum('status', ['not_started', 'in_progress', 'completed'])->default('not_started');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('cards');
+    }
+};


### PR DESCRIPTION
## Summary
- create migrations for `columns` and `cards_table`
- add `Column` and `Card` models with relationships
- provide factories for the new models
- rename `cards_table` table to `cards`

## Testing
- `php artisan test` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c91a4b69883338a548f5ec04e35d5