### PR TITLE
Add basic session auth API

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Http\Response;
+
+class AuthController extends Controller
+{
+    /**
+     * Handle an authentication attempt.
+     */
+    public function login(Request $request): Response
+    {
+        $credentials = $request->validate([
+            'email' => ['required', 'email'],
+            'password' => ['required'],
+        ]);
+
+        if (Auth::attempt($credentials)) {
+            $request->session()->regenerate();
+
+            return response(
+                ['message' => 'Logged in'],
+                200,
+                ['Content-Type' => 'application/json']
+            );
+        }
+
+        return response(
+            ['message' => 'Invalid credentials'],
+            401,
+            ['Content-Type' => 'application/json']
+        );
+    }
+
+    /**
+     * Log the user out of the application.
+     */
+    public function logout(Request $request): Response
+    {
+        Auth::guard('web')->logout();
+
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+
+        return response(
+            ['message' => 'Logged out'],
+            200,
+            ['Content-Type' => 'application/json']
+        );
+    }
+
+    /**
+     * Get the authenticated user.
+     */
+    public function user(Request $request): Response
+    {
+        return response(
+            ['user' => $request->user()],
+            200,
+            ['Content-Type' => 'application/json']
+        );
+    }
+
+}

--- a/app/Http/Controllers/AuthPingController.php
+++ b/app/Http/Controllers/AuthPingController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Response;
+
+class AuthPingController extends Controller
+{
+    /**
+     * Respond with a simple pong for authenticated users.
+     */
+    public function ping(): Response
+    {
+        return new Response('pong', 200, ['Content-Type' => 'text/plain']);
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -7,6 +7,7 @@ use Illuminate\Foundation\Configuration\Middleware;
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
+        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
     )

--- a/config/cors.php
+++ b/config/cors.php
@@ -74,6 +74,6 @@ return [
     | Whether the browser should send credentials (cookies).
     |--------------------------------------------------------------------------
     */
-    'supports_credentials' => false,
+    'supports_credentials' => true,
 
 ];

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,12 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\AuthController;
+use App\Http\Controllers\AuthPingController;
+
+Route::middleware('web')->group(function () {
+    Route::post('/login', [AuthController::class, 'login']);
+    Route::post('/logout', [AuthController::class, 'logout']);
+    Route::get('/user', [AuthController::class, 'user']);
+    Route::middleware('auth')->get('/ping', [AuthPingController::class, 'ping']);
+});

--- a/tests/Feature/AuthTest.php
+++ b/tests/Feature/AuthTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AuthTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_login_and_logout()
+    {
+        $user = User::factory()->create([
+            'password' => bcrypt('secret')
+        ]);
+
+        $response = $this->post('/api/login', [
+            'email' => $user->email,
+            'password' => 'secret',
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJson(['message' => 'Logged in']);
+        $this->assertAuthenticatedAs($user);
+
+        $response = $this->get('/api/user');
+        $response->assertStatus(200);
+        $response->assertJsonPath('user.id', $user->id);
+
+        $response = $this->post('/api/logout');
+        $response->assertStatus(200);
+        $response->assertJson(['message' => 'Logged out']);
+        $this->assertGuest();
+    }
+
+    public function test_login_returns_success_response()
+    {
+        $user = User::factory()->create([
+            'password' => bcrypt('secret'),
+        ]);
+
+        $response = $this->post('/api/login', [
+            'email' => $user->email,
+            'password' => 'secret',
+        ]);
+
+        $response->assertStatus(200);
+        $response->assertJson(['message' => 'Logged in']);
+        $this->assertAuthenticatedAs($user);
+    }
+
+    public function test_login_fails_with_invalid_credentials()
+    {
+        $user = User::factory()->create([
+            'password' => bcrypt('secret'),
+        ]);
+
+        $response = $this->post('/api/login', [
+            'email' => $user->email,
+            'password' => 'wrong-password',
+        ]);
+
+        $response->assertStatus(401);
+        $response->assertJson(['message' => 'Invalid credentials']);
+        $this->assertGuest();
+    }
+
+    public function test_user_endpoint_returns_authenticated_user()
+    {
+        $user = User::factory()->create([
+            'password' => bcrypt('secret'),
+        ]);
+
+        $this->post('/api/login', [
+            'email' => $user->email,
+            'password' => 'secret',
+        ])->assertStatus(200);
+
+        $response = $this->get('/api/user');
+
+        $response->assertStatus(200);
+        $response->assertJsonPath('user.id', $user->id);
+    }
+
+    public function test_logout_logs_out_user()
+    {
+        $user = User::factory()->create([
+            'password' => bcrypt('secret'),
+        ]);
+
+        $this->post('/api/login', [
+            'email' => $user->email,
+            'password' => 'secret',
+        ])->assertStatus(200);
+
+        $response = $this->post('/api/logout');
+
+        $response->assertStatus(200);
+        $response->assertJson(['message' => 'Logged out']);
+        $this->assertGuest();
+    }
+}
+

--- a/tests/Feature/AuthenticatedPingTest.php
+++ b/tests/Feature/AuthenticatedPingTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AuthenticatedPingTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_authenticated_user_can_ping()
+    {
+        $user = User::factory()->create([
+            'password' => bcrypt('secret'),
+        ]);
+
+        $this->post('/api/login', [
+            'email' => $user->email,
+            'password' => 'secret',
+        ])->assertStatus(200);
+
+        $response = $this->get('/api/ping');
+
+        $response->assertStatus(200);
+        $response->assertSeeText('pong');
+        $response->assertHeader('Content-Type', 'text/plain; charset=UTF-8');
+    }
+
+    public function test_ping_requires_authentication()
+    {
+        $response = $this->get('/api/ping', [
+            'Accept' => 'application/json',
+        ]);
+
+        $response->assertStatus(401);
+        $response->assertJson(['message' => 'Unauthenticated.']);
+    }
+}


### PR DESCRIPTION
## Summary
- add AuthController with login/logout/user actions
- expose new endpoints via `routes/api.php`
- load API routes in the app bootstrap
- allow CORS requests with credentials
- provide feature tests for authentication
- add authenticated ping endpoint
- expand tests covering each auth action
- adjust ping test for API-only responses
- split ping handler into new `AuthPingController`

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e4b74d9fc8333a20b1565332b6ca8