### PR TITLE
Implement JSON auth middleware

### DIFF
--- a/app/Http/Middleware/Authenticate.php
+++ b/app/Http/Middleware/Authenticate.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Auth\Middleware\Authenticate as Middleware;
+use Illuminate\Auth\AuthenticationException;
+
+class Authenticate extends Middleware
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Illuminate\Http\Request  $request
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     * @param  string|null  ...$guards
+     */
+    public function handle($request, Closure $next, ...$guards)
+    {
+        try {
+            return parent::handle($request, $next, ...$guards);
+        } catch (AuthenticationException $e) {
+            return response()->json(['message' => 'Unauthenticated.'], 401);
+        }
+    }
+
+    protected function redirectTo($request)
+    {
+        return null;
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -12,7 +12,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
-        //
+        $middleware->alias([
+            'auth' => \App\Http\Middleware\Authenticate::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/tests/Feature/UnauthenticatedPingWithoutAcceptHeaderTest.php
+++ b/tests/Feature/UnauthenticatedPingWithoutAcceptHeaderTest.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace Tests\Feature;
+
+use Tests\TestCase;
+
+class UnauthenticatedPingWithoutAcceptHeaderTest extends TestCase
+{
+    public function test_ping_without_accept_header_returns_json_unauthenticated()
+    {
+        $response = $this->get('/api/ping');
+
+        $response->assertStatus(401);
+        $response->assertExactJson(['message' => 'Unauthenticated.']);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add custom authentication middleware returning JSON 401 responses
- register custom auth middleware alias
- test unauthorized `/api/ping` without Accept header

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6851d22778888333bd9f98111f13cba2