### PR TITLE
Add validation error tests and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,13 @@ php artisan serve --host=0.0.0.0 --port=8000
 ```
 
 - Open your browser at: http://localhost:8000/ping
+
+## API Usage
+
+To receive JSON validation errors when calling the API, include the header:
+
+```
+Accept: application/json
+```
+
+Without this header Laravel may return an HTML response on validation failure.

--- a/tests/Feature/AuthApiTest.php
+++ b/tests/Feature/AuthApiTest.php
@@ -37,6 +37,22 @@ class AuthApiTest extends TestCase
         $response->assertJsonStructure(['token']);
     }
 
+    public function test_register_validation_errors_are_returned_for_invalid_data(): void
+    {
+        $response = $this->postJson('/api/register', []);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['name', 'email', 'password']);
+    }
+
+    public function test_login_validation_errors_are_returned_for_invalid_data(): void
+    {
+        $response = $this->postJson('/api/login', []);
+
+        $response->assertStatus(422);
+        $response->assertJsonValidationErrors(['email', 'password']);
+    }
+
     public function test_user_and_logout_endpoints_require_authentication(): void
     {
         $this->getJson('/api/user')->assertUnauthorized();


### PR DESCRIPTION
## Summary
- test validation error handling on /api/register and /api/login
- document `Accept: application/json` requirement for API clients

## Testing
- `./vendor/bin/phpunit --stop-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_6862c594db308333baf828dad7609a2d