### PR TITLE
Add order column with triggers

### DIFF
--- a/app/Models/Card.php
+++ b/app/Models/Card.php
@@ -9,6 +9,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 /**
  * @property int $id
  * @property int $column_id
+ * @property int $order
  * @property string $title
  * @property string $status
  */
@@ -20,6 +21,7 @@ class Card extends Model
 
     protected $fillable = [
         'column_id',
+        'order',
         'title',
         'status',
     ];

--- a/database/migrations/2025_07_01_000001_add_order_to_cards_table.php
+++ b/database/migrations/2025_07_01_000001_add_order_to_cards_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('cards', function (Blueprint $table) {
+            $table->unsignedInteger('order')->after('column_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('cards', function (Blueprint $table) {
+            $table->dropColumn('order');
+        });
+    }
+};

--- a/database/migrations/2025_07_01_000002_create_card_order_triggers.php
+++ b/database/migrations/2025_07_01_000002_create_card_order_triggers.php
@@ -1,0 +1,63 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::unprepared(<<<'SQL'
+CREATE TRIGGER before_insert_card
+BEFORE INSERT ON cards
+FOR EACH ROW
+BEGIN
+    IF NEW.`order` IS NULL THEN
+        SET NEW.`order` = COALESCE((SELECT MAX(`order`) FROM cards WHERE column_id = NEW.column_id), 0) + 1;
+    ELSE
+        UPDATE cards
+        SET `order` = `order` + 1
+        WHERE column_id = NEW.column_id
+          AND `order` >= NEW.`order`;
+    END IF;
+END
+SQL);
+
+        DB::unprepared(<<<'SQL'
+CREATE TRIGGER before_update_card_order
+BEFORE UPDATE ON cards
+FOR EACH ROW
+BEGIN
+    IF NEW.`order` <> OLD.`order` THEN
+        IF NEW.`order` > OLD.`order` THEN
+            UPDATE cards
+            SET `order` = `order` - 1
+            WHERE column_id = NEW.column_id
+              AND `order` <= NEW.`order`
+              AND `order` > OLD.`order`
+              AND id <> OLD.id;
+        ELSE
+            UPDATE cards
+            SET `order` = `order` + 1
+            WHERE column_id = NEW.column_id
+              AND `order` >= NEW.`order`
+              AND `order` < OLD.`order`
+              AND id <> OLD.id;
+        END IF;
+    END IF;
+END
+SQL);
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::unprepared('DROP TRIGGER IF EXISTS before_insert_card');
+        DB::unprepared('DROP TRIGGER IF EXISTS before_update_card_order');
+    }
+};


### PR DESCRIPTION
## Summary
- add a migration to add an `order` column to the `cards` table positioned after `column_id`
- keep triggers to maintain ordering when inserting or updating cards
- revert modifications to the original cards table migration
- update Card model doc block and fillable ordering
- enhance insert trigger to shift existing orders when `order` is specified

## Testing
- `composer install` *(fails: command not found)*
- `php artisan test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862f96122b083339bc4645236d7ac5b