### PR TITLE
Implement application-level card ordering

### DIFF
--- a/app/Observers/CardObserver.php
+++ b/app/Observers/CardObserver.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\Card;
+
+class CardObserver
+{
+    public function creating(Card $card): void
+    {
+        if ($card->order === null) {
+            $card->order = Card::where('column_id', $card->column_id)->max('order') + 1;
+        } else {
+            Card::where('column_id', $card->column_id)
+                ->where('order', '>=', $card->order)
+                ->increment('order');
+        }
+    }
+
+    public function updating(Card $card): void
+    {
+        $originalColumn = $card->getOriginal('column_id');
+        $originalOrder = $card->getOriginal('order');
+
+        if ($card->column_id !== $originalColumn) {
+            Card::where('column_id', $originalColumn)
+                ->where('order', '>', $originalOrder)
+                ->decrement('order');
+
+            if ($card->order === null) {
+                $card->order = Card::where('column_id', $card->column_id)->max('order') + 1;
+            } else {
+                Card::where('column_id', $card->column_id)
+                    ->where('order', '>=', $card->order)
+                    ->increment('order');
+            }
+        } elseif ($card->order !== $originalOrder) {
+            if ($card->order > $originalOrder) {
+                Card::where('column_id', $card->column_id)
+                    ->where('order', '<=', $card->order)
+                    ->where('order', '>', $originalOrder)
+                    ->decrement('order');
+            } else {
+                Card::where('column_id', $card->column_id)
+                    ->where('order', '>=', $card->order)
+                    ->where('order', '<', $originalOrder)
+                    ->increment('order');
+            }
+        }
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,8 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use App\Models\Card;
+use App\Observers\CardObserver;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -19,6 +21,6 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        Card::observe(CardObserver::class);
     }
 }

--- a/database/migrations/2025_07_01_000003_drop_card_order_triggers.php
+++ b/database/migrations/2025_07_01_000003_drop_card_order_triggers.php
@@ -1,0 +1,18 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::unprepared('DROP TRIGGER IF EXISTS before_insert_card');
+        DB::unprepared('DROP TRIGGER IF EXISTS before_update_card_order');
+    }
+
+    public function down(): void
+    {
+        // No-op: triggers were dropped intentionally
+    }
+};

--- a/tests/Unit/CardOrderTest.php
+++ b/tests/Unit/CardOrderTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Models\Card;
+use App\Models\Column;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CardOrderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_creating_cards_assigns_incremental_order(): void
+    {
+        $user = User::factory()->create();
+        $column = Column::factory()->for($user)->create();
+
+        $card1 = Card::factory()->for($column)->create();
+        $card2 = Card::factory()->for($column)->create();
+
+        $this->assertEquals(1, $card1->order);
+        $this->assertEquals(2, $card2->order);
+    }
+
+    public function test_updating_card_order_shifts_neighbors(): void
+    {
+        $user = User::factory()->create();
+        $column = Column::factory()->for($user)->create();
+
+        $cardA = Card::factory()->for($column)->create();
+        $cardB = Card::factory()->for($column)->create();
+        $cardC = Card::factory()->for($column)->create();
+
+        $cardC->update(['order' => 1]);
+        $cardA->refresh();
+        $cardB->refresh();
+        $cardC->refresh();
+
+        $this->assertEquals(1, $cardC->order);
+        $this->assertEquals(2, $cardA->order);
+        $this->assertEquals(3, $cardB->order);
+    }
+}


### PR DESCRIPTION
## Summary
- drop existing DB triggers with a migration
- handle card ordering in a new `CardObserver`
- register observer in `AppServiceProvider`
- test ordering logic with unit tests

## Testing
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68630367b468833397f4f43489b99e70