### PR TITLE
Add request validation for year/month and card position

### DIFF
--- a/app/Http/Controllers/CardController.php
+++ b/app/Http/Controllers/CardController.php
@@ -5,7 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\Card;
 use App\Services\CardService;
 use App\Services\ColumnService;
-use App\Http\Requests\UpdateCardPositionRequest;
+use App\Http\Requests\PositionRequest;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -57,7 +57,7 @@ class CardController extends Controller
         return response()->json($card);
     }
 
-    public function updatePosition(UpdateCardPositionRequest $request, Card $card)
+    public function updatePosition(PositionRequest $request, Card $card)
     {
         $data = $request->validated();
 

--- a/app/Http/Controllers/CardController.php
+++ b/app/Http/Controllers/CardController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Models\Card;
 use App\Services\CardService;
 use App\Services\ColumnService;
+use App\Http\Requests\UpdateCardPositionRequest;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -56,13 +57,9 @@ class CardController extends Controller
         return response()->json($card);
     }
 
-    public function updatePosition(Request $request, Card $card)
+    public function updatePosition(UpdateCardPositionRequest $request, Card $card)
     {
-        $data = $request->validate([
-            'year'  => "required|integer|min:2000|max:4000",
-            'month' => 'required|integer|min:1|max:12',
-            'order' => 'required|integer|min:1',
-        ]);
+        $data = $request->validated();
 
         $column = $this->columns->findOrCreate($data['year'], $data['month'], $request->user()->id);
 

--- a/app/Http/Controllers/ColumnController.php
+++ b/app/Http/Controllers/ColumnController.php
@@ -3,7 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Services\ColumnService;
-use Illuminate\Http\Request;
+use App\Http\Requests\YearMonthRequest;
 
 class ColumnController extends Controller
 {
@@ -11,9 +11,10 @@ class ColumnController extends Controller
     {
     }
 
-    public function cards(Request $request, int $year, int $month)
+    public function cards(YearMonthRequest $request)
     {
-        $column = $this->columns->findOrCreate($year, $month, $request->user()->id);
+        $data = $request->validated();
+        $column = $this->columns->findOrCreate($data['year'], $data['month'], $request->user()->id);
 
         $cards = $column->cards()
             ->orderBy('order')

--- a/app/Http/Requests/PositionRequest.php
+++ b/app/Http/Requests/PositionRequest.php
@@ -2,7 +2,7 @@
 
 namespace App\Http\Requests;
 
-class UpdateCardPositionRequest extends YearMonthRequest
+class PositionRequest extends YearMonthRequest
 {
     public function rules(): array
     {

--- a/app/Http/Requests/UpdateCardPositionRequest.php
+++ b/app/Http/Requests/UpdateCardPositionRequest.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App\Http\Requests;
+
+class UpdateCardPositionRequest extends YearMonthRequest
+{
+    public function rules(): array
+    {
+        return array_merge(parent::rules(), [
+            'order' => 'required|integer|min:1',
+        ]);
+    }
+}

--- a/app/Http/Requests/YearMonthRequest.php
+++ b/app/Http/Requests/YearMonthRequest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class YearMonthRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    public function rules(): array
+    {
+        return [
+            'year'  => 'required|integer|min:2000|max:4000',
+            'month' => 'required|integer|min:1|max:12',
+        ];
+    }
+
+    protected function validationData(): array
+    {
+        return array_merge($this->all(), $this->route()?->parameters() ?? []);
+    }
+}

--- a/app/Http/Requests/YearMonthRequest.php
+++ b/app/Http/Requests/YearMonthRequest.php
@@ -19,7 +19,7 @@ class YearMonthRequest extends FormRequest
         ];
     }
 
-    protected function validationData(): array
+    public function validationData(): array
     {
         return array_merge($this->all(), $this->route()?->parameters() ?? []);
     }

--- a/tests/Feature/CardApiTest.php
+++ b/tests/Feature/CardApiTest.php
@@ -113,5 +113,32 @@ class CardApiTest extends TestCase
         $this->assertDatabaseMissing('cards', ['id' => $cardId]);
     }
 
+    public function test_cards_endpoint_returns_validation_errors_for_invalid_year_or_month(): void
+    {
+        $user = User::factory()->create();
+        $headers = $this->authHeaders($user);
+
+        $res = $this->getJson('/api/v1/columns/1999/13/cards', $headers);
+        $res->assertStatus(422);
+        $res->assertJsonValidationErrors(['year', 'month']);
+    }
+
+    public function test_update_position_returns_validation_errors_for_invalid_year_or_month(): void
+    {
+        $user = User::factory()->create();
+        $column = Column::factory()->for($user)->create(['year' => 2025, 'month' => 6]);
+        $card = Card::factory()->for($column)->create(['order' => 1]);
+        $headers = $this->authHeaders($user);
+
+        $res = $this->patchJson("/api/v1/cards/{$card->id}/position", [
+            'year' => 1999,
+            'month' => 13,
+            'order' => 1,
+        ], $headers);
+
+        $res->assertStatus(422);
+        $res->assertJsonValidationErrors(['year', 'month']);
+    }
+
     
 }


### PR DESCRIPTION
## Summary
- add `YearMonthRequest` base form request
- add `UpdateCardPositionRequest` that extends `YearMonthRequest`
- use these requests in `ColumnController` and `CardController`
- add feature tests checking invalid year/month handling

## Testing
- `composer test` *(fails: php or composer not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6864399459648333aafeaea863fba6e4