### PR TITLE
Add per-card authorization

### DIFF
--- a/app/Http/Controllers/CardController.php
+++ b/app/Http/Controllers/CardController.php
@@ -32,11 +32,15 @@ class CardController extends Controller
 
     public function show(Card $card)
     {
+        $this->authorize('view', $card);
+
         return response()->json($card);
     }
 
     public function updateTitle(Request $request, Card $card)
     {
+        $this->authorize('update', $card);
+
         $data = $request->validate([
             'title' => 'required|string|min:0|max:255',
         ]);
@@ -48,6 +52,8 @@ class CardController extends Controller
 
     public function updateStatus(Request $request, Card $card)
     {
+        $this->authorize('update', $card);
+
         $data = $request->validate([
             'status' => 'required|in:not_started,in_progress,completed',
         ]);
@@ -59,6 +65,8 @@ class CardController extends Controller
 
     public function updatePosition(PositionRequest $request, Card $card)
     {
+        $this->authorize('update', $card);
+
         $data = $request->validated();
 
         $column = $this->columns->firstOrCreate($data['year'], $data['month'], $request->user()->id);
@@ -70,6 +78,8 @@ class CardController extends Controller
 
     public function destroy(Card $card)
     {
+        $this->authorize('delete', $card);
+
         $this->cards->delete($card);
 
         return response()->noContent();

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -2,7 +2,10 @@
 
 namespace App\Http\Controllers;
 
-abstract class Controller
+use Illuminate\Foundation\Auth\Access\AuthorizesRequests;
+use Illuminate\Routing\Controller as BaseController;
+
+abstract class Controller extends BaseController
 {
-    //
+    use AuthorizesRequests;
 }

--- a/app/Policies/CardPolicy.php
+++ b/app/Policies/CardPolicy.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Card;
+use App\Models\User;
+
+class CardPolicy
+{
+    /**
+     * Determine whether the user can view the card.
+     */
+    public function view(User $user, Card $card): bool
+    {
+        return $card->column->user_id === $user->id;
+    }
+
+    /**
+     * Determine whether the user can update the card.
+     */
+    public function update(User $user, Card $card): bool
+    {
+        return $card->column->user_id === $user->id;
+    }
+
+    /**
+     * Determine whether the user can delete the card.
+     */
+    public function delete(User $user, Card $card): bool
+    {
+        return $card->column->user_id === $user->id;
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Providers;
+
+use App\Models\Card;
+use App\Policies\CardPolicy;
+use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
+
+class AuthServiceProvider extends ServiceProvider
+{
+    /**
+     * The policy mappings for the application.
+     *
+     * @var array<class-string, class-string>
+     */
+    protected $policies = [
+        Card::class => CardPolicy::class,
+    ];
+
+    /**
+     * Register any authentication / authorization services.
+     */
+    public function boot(): void
+    {
+        //
+    }
+}

--- a/bootstrap/providers.php
+++ b/bootstrap/providers.php
@@ -2,4 +2,5 @@
 
 return [
     App\Providers\AppServiceProvider::class,
+    App\Providers\AuthServiceProvider::class,
 ];

--- a/routes/api.php
+++ b/routes/api.php
@@ -14,11 +14,16 @@ Route::prefix('v1')->group(function () {
 
         Route::get('/columns/{year}/{month}/cards', [\App\Http\Controllers\ColumnController::class, 'cards']);
         Route::post('/cards', [\App\Http\Controllers\CardController::class, 'store']);
-        Route::get('/cards/{card}', [\App\Http\Controllers\CardController::class, 'show']);
-        Route::patch('/cards/{card}/title', [\App\Http\Controllers\CardController::class, 'updateTitle']);
-        Route::patch('/cards/{card}/status', [\App\Http\Controllers\CardController::class, 'updateStatus']);
-        Route::patch('/cards/{card}/position', [\App\Http\Controllers\CardController::class, 'updatePosition']);
-        Route::delete('/cards/{card}', [\App\Http\Controllers\CardController::class, 'destroy']);
+        Route::get('/cards/{card}', [\App\Http\Controllers\CardController::class, 'show'])
+            ->middleware('can:view,card');
+        Route::patch('/cards/{card}/title', [\App\Http\Controllers\CardController::class, 'updateTitle'])
+            ->middleware('can:update,card');
+        Route::patch('/cards/{card}/status', [\App\Http\Controllers\CardController::class, 'updateStatus'])
+            ->middleware('can:update,card');
+        Route::patch('/cards/{card}/position', [\App\Http\Controllers\CardController::class, 'updatePosition'])
+            ->middleware('can:update,card');
+        Route::delete('/cards/{card}', [\App\Http\Controllers\CardController::class, 'destroy'])
+            ->middleware('can:delete,card');
     });
 });
 

--- a/tests/Feature/CardAuthorizationTest.php
+++ b/tests/Feature/CardAuthorizationTest.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Card;
+use App\Models\Column;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Auth\Middleware\Authorize;
+use Tests\TestCase;
+
+class CardAuthorizationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private function setUpCard(): array
+    {
+        $owner = User::factory()->create();
+        $column = Column::factory()->for($owner)->create(['year' => 2025, 'month' => 7]);
+        $card = Card::factory()->for($column)->create(['order' => 1]);
+        $other = User::factory()->create();
+
+        return [$card, $owner, $other];
+    }
+
+    /* Route middleware */
+    public function test_route_blocks_viewing_foreign_card(): void
+    {
+        [$card, , $other] = $this->setUpCard();
+
+        $res = $this->getJson("/api/v1/cards/{$card->id}", $this->authHeaders($other));
+        $res->assertForbidden();
+    }
+
+    public function test_route_blocks_updating_title_of_foreign_card(): void
+    {
+        [$card, , $other] = $this->setUpCard();
+
+        $res = $this->patchJson(
+            "/api/v1/cards/{$card->id}/title",
+            ['title' => 'New'],
+            $this->authHeaders($other)
+        );
+        $res->assertForbidden();
+    }
+
+    public function test_route_blocks_updating_status_of_foreign_card(): void
+    {
+        [$card, , $other] = $this->setUpCard();
+
+        $res = $this->patchJson(
+            "/api/v1/cards/{$card->id}/status",
+            ['status' => 'completed'],
+            $this->authHeaders($other)
+        );
+        $res->assertForbidden();
+    }
+
+    public function test_route_blocks_updating_position_of_foreign_card(): void
+    {
+        [$card, , $other] = $this->setUpCard();
+
+        $res = $this->patchJson(
+            "/api/v1/cards/{$card->id}/position",
+            ['year' => 2025, 'month' => 8, 'order' => 1],
+            $this->authHeaders($other)
+        );
+        $res->assertForbidden();
+    }
+
+    public function test_route_blocks_deleting_foreign_card(): void
+    {
+        [$card, , $other] = $this->setUpCard();
+
+        $res = $this->deleteJson(
+            "/api/v1/cards/{$card->id}",
+            [],
+            $this->authHeaders($other)
+        );
+        $res->assertForbidden();
+    }
+
+    /* Controller authorize */
+    public function test_controller_blocks_viewing_foreign_card(): void
+    {
+        [$card, , $other] = $this->setUpCard();
+        $this->withoutMiddleware([Authorize::class]);
+
+        $res = $this->getJson("/api/v1/cards/{$card->id}", $this->authHeaders($other));
+        $res->assertForbidden();
+    }
+
+    public function test_controller_blocks_updating_title_of_foreign_card(): void
+    {
+        [$card, , $other] = $this->setUpCard();
+        $this->withoutMiddleware([Authorize::class]);
+
+        $res = $this->patchJson(
+            "/api/v1/cards/{$card->id}/title",
+            ['title' => 'New'],
+            $this->authHeaders($other)
+        );
+        $res->assertForbidden();
+    }
+
+    public function test_controller_blocks_updating_status_of_foreign_card(): void
+    {
+        [$card, , $other] = $this->setUpCard();
+        $this->withoutMiddleware([Authorize::class]);
+
+        $res = $this->patchJson(
+            "/api/v1/cards/{$card->id}/status",
+            ['status' => 'completed'],
+            $this->authHeaders($other)
+        );
+        $res->assertForbidden();
+    }
+
+    public function test_controller_blocks_updating_position_of_foreign_card(): void
+    {
+        [$card, , $other] = $this->setUpCard();
+        $this->withoutMiddleware([Authorize::class]);
+
+        $res = $this->patchJson(
+            "/api/v1/cards/{$card->id}/position",
+            ['year' => 2025, 'month' => 8, 'order' => 1],
+            $this->authHeaders($other)
+        );
+        $res->assertForbidden();
+    }
+
+    public function test_controller_blocks_deleting_foreign_card(): void
+    {
+        [$card, , $other] = $this->setUpCard();
+        $this->withoutMiddleware([Authorize::class]);
+
+        $res = $this->deleteJson(
+            "/api/v1/cards/{$card->id}",
+            [],
+            $this->authHeaders($other)
+        );
+        $res->assertForbidden();
+    }
+}
+


### PR DESCRIPTION
## Summary
- add CardPolicy to authorize viewing, updating and deleting cards
- register new policy in AuthServiceProvider
- invoke policy checks in CardController
- secure card routes with `can` middleware
- test both route and controller authorization paths

## Testing
- `composer install` *(fails: composer not found)*
- `php artisan test` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_6867e548934883338c749d7b2b6d3168