### PR TITLE
Add missing tests for login and card endpoints

### DIFF
--- a/tests/Feature/AuthApiTest.php
+++ b/tests/Feature/AuthApiTest.php
@@ -37,6 +37,19 @@ class AuthApiTest extends TestCase
         $response->assertJsonStructure(['token']);
     }
 
+    public function test_login_returns_error_for_invalid_credentials(): void
+    {
+        $user = User::factory()->create(['password' => Hash::make('secret123')]);
+
+        $response = $this->postJson('/api/v1/login', [
+            'email' => $user->email,
+            'password' => 'wrong-password',
+        ]);
+
+        $response->assertStatus(401);
+        $response->assertExactJson(['message' => 'Invalid credentials']);
+    }
+
     public function test_register_validation_errors_are_returned_for_invalid_data(): void
     {
         $response = $this->postJson('/api/v1/register', []);

--- a/tests/Feature/CardApiSadPathTest.php
+++ b/tests/Feature/CardApiSadPathTest.php
@@ -79,6 +79,14 @@ class CardApiSadPathTest extends TestCase
             ->assertJsonValidationErrors(['title']);
     }
 
+    public function test_update_title_returns_not_found_for_invalid_card_id(): void
+    {
+        $user = User::factory()->create();
+
+        $this->patchJson('/api/v1/cards/999/title', ['title' => 'New'], $this->authHeaders($user))
+            ->assertNotFound();
+    }
+
     public function test_update_status_requires_authentication(): void
     {
         $card = Card::factory()->for(Column::factory()->for(User::factory()->create()))->create();
@@ -95,6 +103,14 @@ class CardApiSadPathTest extends TestCase
         $this->patchJson("/api/v1/cards/{$card->id}/status", ['status' => 'bad'], $this->authHeaders($user))
             ->assertStatus(422)
             ->assertJsonValidationErrors(['status']);
+    }
+
+    public function test_update_status_returns_not_found_for_invalid_card_id(): void
+    {
+        $user = User::factory()->create();
+
+        $this->patchJson('/api/v1/cards/999/status', ['status' => 'completed'], $this->authHeaders($user))
+            ->assertNotFound();
     }
 
     public function test_update_position_requires_authentication(): void

--- a/tests/Feature/CardApiTest.php
+++ b/tests/Feature/CardApiTest.php
@@ -76,6 +76,23 @@ class CardApiTest extends TestCase
         $res->assertJsonPath('cards.2.order', 3);
     }
 
+    public function test_show_card_returns_card(): void
+    {
+        $user = User::factory()->create();
+        $column = Column::factory()->for($user)->create(['year' => 2025, 'month' => 6]);
+        $card = Card::factory()->for($column)->create(['order' => 1, 'title' => 'My Card']);
+
+        $res = $this->getJson("/api/v1/cards/{$card->id}", $this->authHeaders($user));
+
+        $res->assertOk();
+        $res->assertJson([
+            'id' => $card->id,
+            'title' => 'My Card',
+            'order' => 1,
+            'column_id' => $column->id,
+        ]);
+    }
+
     public function test_card_lifecycle(): void
     {
         // create a user and a column for that user


### PR DESCRIPTION
## Summary
- add invalid credentials test in AuthApiTest
- add show card success test in CardApiTest
- add not-found tests for card title and status updates

## Testing
- `vendor/bin/phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68683e7cbb40833391aab4787b78b766