### PR TITLE
Reset ColumnFactory sequence before each test

### DIFF
--- a/database/factories/ColumnFactory.php
+++ b/database/factories/ColumnFactory.php
@@ -14,6 +14,11 @@ class ColumnFactory extends Factory
      */
     protected static int $sequence = 0;
 
+    public static function resetSequence(): void
+    {
+        self::$sequence = 0;
+    }
+
     public function definition(): array
     {
         $year = now()->year + intdiv(self::$sequence, 12);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -11,6 +11,12 @@ abstract class TestCase extends BaseTestCase
 {
     use CreatesApplication;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+        \Database\Factories\ColumnFactory::resetSequence();
+    }
+
     protected function authHeaders(User $user): array
     {
         $token = $user->createToken('api')->plainTextToken;


### PR DESCRIPTION
## Summary
- add `resetSequence` method to `ColumnFactory`
- call `ColumnFactory::resetSequence` in `TestCase::setUp`

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_6868ec2ebd988333a3c6e2beb57da778