### PR TITLE
Add lint script and CI lint step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,33 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: mbstring, exif, pcntl, bcmath, gd
+          coverage: none
+
+      - name: Install Composer dependencies
+        run: |
+          composer install --prefer-dist --no-progress --no-interaction
+          cp .env.example .env
+          php artisan key:generate
+
+      - name: Run Pint
+        run: composer lint
+
+      - name: Run tests
+        run: composer test

--- a/README.md
+++ b/README.md
@@ -81,6 +81,14 @@ docker exec -it php-laravel-roadmap-backend php artisan test
 php artisan test
 ```
 
+### Linting
+
+Run Laravel Pint to ensure code style matches the project standard:
+
+```bash
+composer lint
+```
+
 ## API Usage
 
 To receive JSON validation errors when calling the API, include the header:

--- a/composer.json
+++ b/composer.json
@@ -52,6 +52,7 @@
             "Composer\\Config::disableProcessTimeout",
             "npx concurrently -c \"#93c5fd,#c4b5fd,#fb7185,#fdba74\" \"php artisan serve\" \"php artisan queue:listen --tries=1\" \"php artisan pail --timeout=0\" \"npm run dev\" --names=server,queue,logs,vite"
         ],
+        "lint": "./vendor/bin/pint --test",
         "test": [
             "@php artisan config:clear --ansi",
             "@php artisan test"


### PR DESCRIPTION
## Summary
- add `lint` composer script using Pint
- run `composer lint` in new CI workflow before tests
- document linting in README

## Testing
- `composer lint` *(fails: command not found)*
- `composer test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868f5e4b1c88333beefcb98f6dbff67