### PR TITLE
Add explicit JsonResponse return types

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers;
 
 use App\Models\User;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Hash;
 use Symfony\Component\HttpFoundation\Response;
@@ -12,7 +13,7 @@ class AuthController extends Controller
     /**
      * Register a new user and return token.
      */
-    public function register(Request $request)
+    public function register(Request $request): JsonResponse
     {
         $data = $request->validate([
             'name' => 'required|string|max:255',
@@ -34,7 +35,7 @@ class AuthController extends Controller
     /**
      * Authenticate user and return token.
      */
-    public function login(Request $request)
+    public function login(Request $request): JsonResponse
     {
         $data = $request->validate([
             'email' => 'required|email',
@@ -55,7 +56,7 @@ class AuthController extends Controller
     /**
      * Revoke current token.
      */
-    public function logout(Request $request)
+    public function logout(Request $request): JsonResponse
     {
         $request->user()->currentAccessToken()->delete();
 
@@ -65,7 +66,7 @@ class AuthController extends Controller
     /**
      * Return authenticated user profile.
      */
-    public function user(Request $request)
+    public function user(Request $request): JsonResponse
     {
         return response()->json($request->user());
     }
@@ -73,7 +74,7 @@ class AuthController extends Controller
     /**
      * Return authenticated pong message.
      */
-    public function pingAuth()
+    public function pingAuth(): JsonResponse
     {
         return response()->json(['message' => 'authenticated pong']);
     }

--- a/app/Http/Controllers/CardController.php
+++ b/app/Http/Controllers/CardController.php
@@ -6,6 +6,7 @@ use App\Models\Card;
 use App\Services\CardService;
 use App\Services\ColumnService;
 use App\Http\Requests\PositionRequest;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -15,7 +16,7 @@ class CardController extends Controller
     {
     }
 
-    public function store(Request $request)
+    public function store(Request $request): JsonResponse
     {
         $data = $request->validate([
             'column_id' => 'required|exists:columns,id',
@@ -33,14 +34,14 @@ class CardController extends Controller
             ->header('Location', '/api/v1/cards/' . $card->id);
     }
 
-    public function show(Card $card)
+    public function show(Card $card): JsonResponse
     {
         $this->authorize('view', $card);
 
         return response()->json($card);
     }
 
-    public function updateTitle(Request $request, Card $card)
+    public function updateTitle(Request $request, Card $card): JsonResponse
     {
         $this->authorize('update', $card);
 
@@ -53,7 +54,7 @@ class CardController extends Controller
         return response()->json($card);
     }
 
-    public function updateStatus(Request $request, Card $card)
+    public function updateStatus(Request $request, Card $card): JsonResponse
     {
         $this->authorize('update', $card);
 
@@ -66,7 +67,7 @@ class CardController extends Controller
         return response()->json($card);
     }
 
-    public function updatePosition(PositionRequest $request, Card $card)
+    public function updatePosition(PositionRequest $request, Card $card): JsonResponse
     {
         $this->authorize('update', $card);
 
@@ -79,7 +80,7 @@ class CardController extends Controller
         return response()->json($card);
     }
 
-    public function destroy(Card $card)
+    public function destroy(Card $card): Response
     {
         $this->authorize('delete', $card);
 

--- a/app/Http/Controllers/ColumnController.php
+++ b/app/Http/Controllers/ColumnController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Services\ColumnService;
 use App\Http\Requests\YearMonthRequest;
+use Illuminate\Http\JsonResponse;
 
 class ColumnController extends Controller
 {
@@ -11,7 +12,7 @@ class ColumnController extends Controller
     {
     }
 
-    public function cards(YearMonthRequest $request)
+    public function cards(YearMonthRequest $request): JsonResponse
     {
         $data = $request->validated();
         $column = $this->columns->firstOrCreate($data['year'], $data['month'], $request->user()->id);


### PR DESCRIPTION
## Summary
- typehint JsonResponse on controller endpoints
- add imports for JsonResponse

## Testing
- `apt-get update`
- `apt-get install -y php-cli`
- `php -v`
- ❌ `php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && php composer-setup.php --install-dir=/usr/local/bin --filename=composer` (blocked)

------
https://chatgpt.com/codex/tasks/task_e_6868f5e7cb888333b14d17650a02b1cf