### PR TITLE
Document column duplicate handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,3 +117,7 @@ All of our Postman artifacts live in `docs/postman/`.
 | `PATCH`  | `/cards/{id}/position`          | Move card to another column/order |
 | `DELETE` | `/cards/{id}`                   | Delete a card                     |
 
+
+### Database Notes
+
+For information on transaction isolation and how duplicate columns are handled see [docs/database.md](docs/database.md).

--- a/docs/database.md
+++ b/docs/database.md
@@ -1,0 +1,30 @@
+# Database Isolation and Column Handling
+
+Our application expects a relational database that supports transactions. The default setups use SQLite for development and testing but MySQL/PostgreSQL can also be used in production. A minimum of the standard **READ COMMITTED** isolation level is assumed so that each transaction sees committed rows from others.
+
+## Unique columns
+
+Columns are unique for each `year`, `month` and `user_id`. This is enforced at the database level by the `columns_year_month_user_unique` index.
+
+When multiple requests attempt to create the same column concurrently the unique constraint may be triggered. `ColumnService::firstOrCreate` handles this race condition transparently.
+
+```php
+try {
+    return Column::firstOrCreate([
+        'year'    => $year,
+        'month'   => $month,
+        'user_id' => $userId,
+    ]);
+} catch (\Illuminate\Database\QueryException $e) {
+    if ($e->getCode() === '23000') {
+        return Column::where([
+            'year'    => $year,
+            'month'   => $month,
+            'user_id' => $userId,
+        ])->first();
+    }
+    throw $e;
+}
+```
+
+The service first tries to create the row. If a duplicate key violation occurs (SQL state `23000`), it performs a second query to return the previously inserted row instead of failing. This approach ensures concurrent requests always resolve to a single column record.

--- a/tests/Feature/ColumnServiceDuplicateTest.php
+++ b/tests/Feature/ColumnServiceDuplicateTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Services\ColumnService;
+use App\Models\User;
+use App\Models\Column;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ColumnServiceDuplicateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_first_or_create_handles_duplicate_insertion(): void
+    {
+        $service = new ColumnService();
+        $user = User::factory()->create();
+
+        $first = $service->firstOrCreate(2025, 7, $user->id);
+        $this->assertNotNull($first);
+
+        // Simulate a concurrent attempt that would violate the unique constraint
+        $second = $service->firstOrCreate(2025, 7, $user->id);
+
+        // The service should return the existing column
+        $this->assertEquals($first->id, $second->id);
+        $this->assertEquals(1, Column::count());
+    }
+}


### PR DESCRIPTION
## Summary
- add docs on transaction isolation and `ColumnService::firstOrCreate`
- reference the docs from README
- add test for duplicate column creation

## Testing
- `./vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_6868f5ea328883338df3bdffa8c9d09d