### PR TITLE
feat: add GitHub Actions workflow for auditing Laravel application

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,19 @@
+name: Audit Laravel Application
+
+on:
+  push:
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+      - name: Install Composer dependencies
+        run: composer install --prefer-dist --no-interaction --no-progress
+      - name: Run Composer Audit
+        run: composer audit

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -2,25 +2,44 @@ name: Audit Laravel Application
 
 on:
   push:
+  schedule:
+    # Every Monday at midnight (UTC)
+    - cron: '0 0 * * 1'
+  workflow_dispatch:
 
 jobs:
   audit:
     runs-on: ubuntu-latest
     steps:
+      # 1) Check out your code
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Setup PHP
+
+      # 2) Set up PHP & Composer
+      - name: Setup PHP & Composer
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.2'
-      - name: Cache Composer dependencies
-        uses: actions/cache@v3
+          tools: composer
+
+      # 3) Grab Composer's cache directory
+      - name: Get Composer cache dir
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      # 4) Cache Composer downloads between runs
+      - name: Cache Composer downloads
+        uses: actions/cache@v4
         with:
-          path: vendor
+          path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
             ${{ runner.os }}-composer-
-      - name: Install Composer dependencies
-        run: composer install --prefer-dist --no-interaction --no-progress
+
+      # 5) Install only production deps (skip scripts & dev-packages)
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-interaction --no-progress --no-scripts --no-dev
+
+      # 6) Run the security audit (machine-readable JSON)
       - name: Run Composer Audit
-        run: composer audit
+        run: composer audit --format=json

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -13,6 +13,13 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.2'
+      - name: Cache Composer dependencies
+        uses: actions/cache@v3
+        with:
+          path: vendor
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
       - name: Install Composer dependencies
         run: composer install --prefer-dist --no-interaction --no-progress
       - name: Run Composer Audit

--- a/.github/workflows/laravel-dreamhost-deploy.yml
+++ b/.github/workflows/laravel-dreamhost-deploy.yml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  roadmap-backend-deploy:
+  deploy:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,13 +7,35 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
+      # 1) Checkout
       - name: Checkout code
         uses: actions/checkout@v4
+
+      # 2) Setup PHP & Composer
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.2'
+          tools: composer
+
+      # 3) Grab Composer's cache dir
+      - name: Get Composer cache dir
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      # 4) Cache Composer downloads
+      - name: Cache Composer downloads
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      # 5) Install ALL deps (you need dev deps for Pint)
       - name: Install Composer dependencies
         run: composer install --prefer-dist --no-interaction --no-progress
+
+      # 6) Run Pint
       - name: Run Pint for code style
         run: composer lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,20 +7,46 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
+      # 1) Checkout your code
       - name: Checkout code
         uses: actions/checkout@v4
-      - name: Setup PHP
+
+      # 2) Set up PHP (with pcntl) & Composer
+      - name: Setup PHP & Composer
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.2'
           extensions: pcntl
+          tools: composer
+
+      # 3) Locate Composer's cache directory
+      - name: Get Composer cache dir
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      # 4) Cache those download artifacts
+      - name: Cache Composer downloads
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-
+
+      # 5) Install all dependencies (including dev)
       - name: Install Composer dependencies
         run: composer install --prefer-dist --no-interaction --no-progress
+
+      # 6) Prepare environment
       - name: Copy .env.example to .env
         run: cp .env.example .env
       - name: Generate application key
         run: php artisan key:generate
-      - name: Run tests
+
+      # 7) Run your test suite
+      - name: Run PHPUnit tests
         run: php artisan test
+
+      # 8) Parallel tests in random order
       - name: Run parallel tests randomly
         run: php artisan test --parallel --processes=4 --order-by=random


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to audit the Laravel application for vulnerabilities using Composer. The workflow is triggered on every push and includes steps for checking out the code, setting up PHP, installing dependencies, and running the Composer audit.

New GitHub Actions workflow:

* [`.github/workflows/audit.yml`](diffhunk://#diff-93a89f16f6717d1e4e4e27ec20ef916e3355c7aa890ca74cd9b12db30d8a899fR1-R19): Introduced a workflow named "Audit Laravel Application" that runs on `ubuntu-latest`, sets up PHP 8.2, installs Composer dependencies, and executes a Composer audit to check for vulnerabilities.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added an automated workflow to audit dependencies for security vulnerabilities on every push, on a weekly schedule, and via manual trigger.
  * Improved dependency caching and setup in linting and testing workflows for faster and more reliable runs.
  * Simplified deployment workflow job naming for clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->