### PR TITLE
Add Composer cache composite action

### DIFF
--- a/.github/actions/composer-cache/action.yml
+++ b/.github/actions/composer-cache/action.yml
@@ -1,0 +1,12 @@
+name: Composer Cache Directory
+description: Outputs Composer cache directory
+outputs:
+  dir:
+    description: Composer cache directory
+    value: ${{ steps.cache-dir.outputs.dir }}
+runs:
+  using: composite
+  steps:
+    - id: cache-dir
+      run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+      shell: bash

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -25,7 +25,7 @@ jobs:
       # 3) Grab Composer's cache directory
       - name: Get Composer cache dir
         id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+        uses: ./.github/actions/composer-cache
 
       # 4) Cache Composer downloads between runs
       - name: Cache Composer downloads

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
       # 3) Grab Composer's cache dir
       - name: Get Composer cache dir
         id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+        uses: ./.github/actions/composer-cache
 
       # 4) Cache Composer downloads
       - name: Cache Composer downloads

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,7 @@ jobs:
       # 3) Locate Composer's cache directory
       - name: Get Composer cache dir
         id: composer-cache
-        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+        uses: ./.github/actions/composer-cache
 
       # 4) Cache those download artifacts
       - name: Cache Composer downloads


### PR DESCRIPTION
## Summary
- create `.github/actions/composer-cache` composite action
- use the composite action in lint/test/audit workflows
- ensure workflows end with a trailing newline

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686c4c8f54ac8333b1eeeb9082ac4b03