### PR TITLE
refactor: retain docs directory during deployment cleanup

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -65,7 +65,10 @@ jobs:
             rm -rf /home/dh_jirb5e/vittoretti.com_roadmap_api_tmp/.env*
             rm -rf /home/dh_jirb5e/vittoretti.com_roadmap_api_tmp/storage/logs/*.log
             rm -rf /home/dh_jirb5e/vittoretti.com_roadmap_api_tmp/tests
-            rm -rf /home/dh_jirb5e/vittoretti.com_roadmap_api_tmp/docs
+            
+            # Keep docs directory (contains OpenAPI specification files)
+            # rm -rf /home/dh_jirb5e/vittoretti.com_roadmap_api_tmp/docs
+            
             rm -rf /home/dh_jirb5e/vittoretti.com_roadmap_api_tmp/Dockerfile*
             rm -rf /home/dh_jirb5e/vittoretti.com_roadmap_api_tmp/docker-compose.yml
             


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * API documentation now reliably persists across deployments. Previously, cleanup could remove the docs directory, making specs temporarily unavailable; this has been corrected to keep OpenAPI files accessible post-deploy, reducing downtime for docs consumers.
* **Chores**
  * Refined deployment workflow to preserve documentation assets during cleanup and added explanatory comments to clarify behavior for future maintenance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->