### PR TITLE
Add L5-Swagger annotations for Roadmap API

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Services\AuthService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use OpenApi\Annotations as OA;
 use Symfony\Component\HttpFoundation\Response;
 
 class AuthController extends Controller

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -21,15 +21,20 @@ class AuthController extends Controller
      *     description="Create a new user account and issue an API token.",
      *     tags={"Auth"},
      *     security={{}},
+     *
      *     @OA\RequestBody(
      *         required=true,
+     *
      *         @OA\JsonContent(ref="#/components/schemas/RegisterRequest")
      *     ),
+     *
      *     @OA\Response(
      *         response=201,
      *         description="User registered successfully",
+     *
      *         @OA\JsonContent(ref="#/components/schemas/AuthTokenResponse")
      *     ),
+     *
      *     @OA\Response(
      *         response=422,
      *         ref="#/components/responses/ValidationError"
@@ -58,20 +63,27 @@ class AuthController extends Controller
      *     description="Issue a Sanctum API token for an existing user.",
      *     tags={"Auth"},
      *     security={{}},
+     *
      *     @OA\RequestBody(
      *         required=true,
+     *
      *         @OA\JsonContent(ref="#/components/schemas/LoginRequest")
      *     ),
+     *
      *     @OA\Response(
      *         response=200,
      *         description="Authentication successful",
+     *
      *         @OA\JsonContent(ref="#/components/schemas/AuthTokenResponse")
      *     ),
+     *
      *     @OA\Response(
      *         response=401,
      *         description="Invalid credentials",
+     *
      *         @OA\JsonContent(ref="#/components/schemas/ErrorMessage")
      *     ),
+     *
      *     @OA\Response(
      *         response=422,
      *         ref="#/components/responses/ValidationError"
@@ -101,11 +113,14 @@ class AuthController extends Controller
      *     path="/api/v1/logout",
      *     summary="Revoke the current token",
      *     tags={"Auth"},
+     *
      *     @OA\Response(
      *         response=200,
      *         description="Logout confirmation",
+     *
      *         @OA\JsonContent(ref="#/components/schemas/MessageResponse")
      *     ),
+     *
      *     @OA\Response(
      *         response=401,
      *         ref="#/components/responses/Unauthenticated"
@@ -126,11 +141,14 @@ class AuthController extends Controller
      *     path="/api/v1/user",
      *     summary="Retrieve the authenticated user profile",
      *     tags={"Auth"},
+     *
      *     @OA\Response(
      *         response=200,
      *         description="Authenticated user profile",
+     *
      *         @OA\JsonContent(ref="#/components/schemas/UserProfile")
      *     ),
+     *
      *     @OA\Response(
      *         response=401,
      *         ref="#/components/responses/Unauthenticated"
@@ -149,11 +167,14 @@ class AuthController extends Controller
      *     path="/api/v1/ping-auth",
      *     summary="Authenticated ping endpoint",
      *     tags={"Auth"},
+     *
      *     @OA\Response(
      *         response=200,
      *         description="Authenticated pong message",
+     *
      *         @OA\JsonContent(ref="#/components/schemas/MessageResponse")
      *     ),
+     *
      *     @OA\Response(
      *         response=401,
      *         ref="#/components/responses/Unauthenticated"

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -13,6 +13,27 @@ class AuthController extends Controller
 
     /**
      * Register a new user and return token.
+     *
+     * @OA\Post(
+     *     path="/api/v1/register",
+     *     summary="Register a new user",
+     *     description="Create a new user account and issue an API token.",
+     *     tags={"Auth"},
+     *     security={{}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(ref="#/components/schemas/RegisterRequest")
+     *     ),
+     *     @OA\Response(
+     *         response=201,
+     *         description="User registered successfully",
+     *         @OA\JsonContent(ref="#/components/schemas/AuthTokenResponse")
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         ref="#/components/responses/ValidationError"
+     *     )
+     * )
      */
     public function register(Request $request): JsonResponse
     {
@@ -29,6 +50,32 @@ class AuthController extends Controller
 
     /**
      * Authenticate user and return token.
+     *
+     * @OA\Post(
+     *     path="/api/v1/login",
+     *     summary="Authenticate a user",
+     *     description="Issue a Sanctum API token for an existing user.",
+     *     tags={"Auth"},
+     *     security={{}},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(ref="#/components/schemas/LoginRequest")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Authentication successful",
+     *         @OA\JsonContent(ref="#/components/schemas/AuthTokenResponse")
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         description="Invalid credentials",
+     *         @OA\JsonContent(ref="#/components/schemas/ErrorMessage")
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         ref="#/components/responses/ValidationError"
+     *     )
+     * )
      */
     public function login(Request $request): JsonResponse
     {
@@ -48,6 +95,21 @@ class AuthController extends Controller
 
     /**
      * Revoke current token.
+     *
+     * @OA\Post(
+     *     path="/api/v1/logout",
+     *     summary="Revoke the current token",
+     *     tags={"Auth"},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Logout confirmation",
+     *         @OA\JsonContent(ref="#/components/schemas/MessageResponse")
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         ref="#/components/responses/Unauthenticated"
+     *     )
+     * )
      */
     public function logout(Request $request): JsonResponse
     {
@@ -58,6 +120,21 @@ class AuthController extends Controller
 
     /**
      * Return authenticated user profile.
+     *
+     * @OA\Get(
+     *     path="/api/v1/user",
+     *     summary="Retrieve the authenticated user profile",
+     *     tags={"Auth"},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Authenticated user profile",
+     *         @OA\JsonContent(ref="#/components/schemas/UserProfile")
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         ref="#/components/responses/Unauthenticated"
+     *     )
+     * )
      */
     public function user(Request $request): JsonResponse
     {
@@ -66,6 +143,21 @@ class AuthController extends Controller
 
     /**
      * Return authenticated pong message.
+     *
+     * @OA\Get(
+     *     path="/api/v1/ping-auth",
+     *     summary="Authenticated ping endpoint",
+     *     tags={"Auth"},
+     *     @OA\Response(
+     *         response=200,
+     *         description="Authenticated pong message",
+     *         @OA\JsonContent(ref="#/components/schemas/MessageResponse")
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         ref="#/components/responses/Unauthenticated"
+     *     )
+     * )
      */
     public function pingAuth(): JsonResponse
     {

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -19,7 +19,7 @@ class AuthController extends Controller
      *     path="/api/v1/register",
      *     summary="Register a new user",
      *     description="Create a new user account and issue an API token.",
-     *     tags={"Auth"},
+     *     tags={"auth"},
      *     security={{}},
      *
      *     @OA\RequestBody(
@@ -61,7 +61,7 @@ class AuthController extends Controller
      *     path="/api/v1/login",
      *     summary="Authenticate a user",
      *     description="Issue a Sanctum API token for an existing user.",
-     *     tags={"Auth"},
+     *     tags={"auth"},
      *     security={{}},
      *
      *     @OA\RequestBody(
@@ -112,7 +112,7 @@ class AuthController extends Controller
      * @OA\Post(
      *     path="/api/v1/logout",
      *     summary="Revoke the current token",
-     *     tags={"Auth"},
+     *     tags={"auth"},
      *
      *     @OA\Response(
      *         response=200,
@@ -140,7 +140,7 @@ class AuthController extends Controller
      * @OA\Get(
      *     path="/api/v1/user",
      *     summary="Retrieve the authenticated user profile",
-     *     tags={"Auth"},
+     *     tags={"auth"},
      *
      *     @OA\Response(
      *         response=200,
@@ -166,7 +166,7 @@ class AuthController extends Controller
      * @OA\Get(
      *     path="/api/v1/ping-auth",
      *     summary="Authenticated ping endpoint",
-     *     tags={"Auth"},
+     *     tags={"auth"},
      *
      *     @OA\Response(
      *         response=200,

--- a/app/Http/Controllers/CardController.php
+++ b/app/Http/Controllers/CardController.php
@@ -14,6 +14,39 @@ class CardController extends Controller
 {
     public function __construct(private CardService $cards, private ColumnService $columns) {}
 
+    /**
+     * @OA\Post(
+     *     path="/api/v1/cards",
+     *     summary="Create a card",
+     *     tags={"Cards"},
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(ref="#/components/schemas/CreateCardRequest")
+     *     ),
+     *     @OA\Response(
+     *         response=201,
+     *         description="Card created",
+     *         @OA\Header(
+     *             header="Location",
+     *             description="URL to the newly created card resource",
+     *             @OA\Schema(type="string", format="uri")
+     *         ),
+     *         @OA\JsonContent(ref="#/components/schemas/Card")
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         ref="#/components/responses/Unauthenticated"
+     *     ),
+     *     @OA\Response(
+     *         response=403,
+     *         ref="#/components/responses/Forbidden"
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         ref="#/components/responses/ValidationError"
+     *     )
+     * )
+     */
     public function store(Request $request): JsonResponse
     {
         $data = $request->validate([
@@ -32,6 +65,31 @@ class CardController extends Controller
             ->header('Location', route('cards.show', $card));
     }
 
+    /**
+     * @OA\Get(
+     *     path="/api/v1/cards/{card}",
+     *     summary="Retrieve a card",
+     *     tags={"Cards"},
+     *     @OA\Parameter(ref="#/components/parameters/CardIdParam"),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Card details",
+     *         @OA\JsonContent(ref="#/components/schemas/CardWithColumn")
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         ref="#/components/responses/Unauthenticated"
+     *     ),
+     *     @OA\Response(
+     *         response=403,
+     *         ref="#/components/responses/Forbidden"
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         ref="#/components/responses/NotFound"
+     *     )
+     * )
+     */
     public function show(Card $card): JsonResponse
     {
         $this->authorize('view', $card);
@@ -39,6 +97,39 @@ class CardController extends Controller
         return response()->json($card);
     }
 
+    /**
+     * @OA\Patch(
+     *     path="/api/v1/cards/{card}/title",
+     *     summary="Update a card title",
+     *     tags={"Cards"},
+     *     @OA\Parameter(ref="#/components/parameters/CardIdParam"),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(ref="#/components/schemas/UpdateTitleRequest")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Updated card",
+     *         @OA\JsonContent(ref="#/components/schemas/CardWithColumn")
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         ref="#/components/responses/Unauthenticated"
+     *     ),
+     *     @OA\Response(
+     *         response=403,
+     *         ref="#/components/responses/Forbidden"
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         ref="#/components/responses/NotFound"
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         ref="#/components/responses/ValidationError"
+     *     )
+     * )
+     */
     public function updateTitle(Request $request, Card $card): JsonResponse
     {
         $this->authorize('update', $card);
@@ -55,6 +146,39 @@ class CardController extends Controller
         return response()->json($card);
     }
 
+    /**
+     * @OA\Patch(
+     *     path="/api/v1/cards/{card}/status",
+     *     summary="Update a card status",
+     *     tags={"Cards"},
+     *     @OA\Parameter(ref="#/components/parameters/CardIdParam"),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(ref="#/components/schemas/UpdateStatusRequest")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Updated card",
+     *         @OA\JsonContent(ref="#/components/schemas/CardWithColumn")
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         ref="#/components/responses/Unauthenticated"
+     *     ),
+     *     @OA\Response(
+     *         response=403,
+     *         ref="#/components/responses/Forbidden"
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         ref="#/components/responses/NotFound"
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         ref="#/components/responses/ValidationError"
+     *     )
+     * )
+     */
     public function updateStatus(Request $request, Card $card): JsonResponse
     {
         $this->authorize('update', $card);
@@ -68,6 +192,39 @@ class CardController extends Controller
         return response()->json($card);
     }
 
+    /**
+     * @OA\Patch(
+     *     path="/api/v1/cards/{card}/position",
+     *     summary="Move a card to a different position or month",
+     *     tags={"Cards"},
+     *     @OA\Parameter(ref="#/components/parameters/CardIdParam"),
+     *     @OA\RequestBody(
+     *         required=true,
+     *         @OA\JsonContent(ref="#/components/schemas/UpdatePositionRequest")
+     *     ),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Updated card",
+     *         @OA\JsonContent(ref="#/components/schemas/CardWithColumn")
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         ref="#/components/responses/Unauthenticated"
+     *     ),
+     *     @OA\Response(
+     *         response=403,
+     *         ref="#/components/responses/Forbidden"
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         ref="#/components/responses/NotFound"
+     *     ),
+     *     @OA\Response(
+     *         response=422,
+     *         ref="#/components/responses/ValidationError"
+     *     )
+     * )
+     */
     public function updatePosition(PositionRequest $request, Card $card): JsonResponse
     {
         $this->authorize('update', $card);
@@ -81,6 +238,31 @@ class CardController extends Controller
         return response()->json($card);
     }
 
+    /**
+     * @OA\Delete(
+     *     path="/api/v1/cards/{card}",
+     *     summary="Delete a card",
+     *     tags={"Cards"},
+     *     @OA\Parameter(ref="#/components/parameters/CardIdParam"),
+     *     @OA\Response(
+     *         response=204,
+     *         description="Card deleted",
+     *         @OA\JsonContent(type="object", example={})
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         ref="#/components/responses/Unauthenticated"
+     *     ),
+     *     @OA\Response(
+     *         response=403,
+     *         ref="#/components/responses/Forbidden"
+     *     ),
+     *     @OA\Response(
+     *         response=404,
+     *         ref="#/components/responses/NotFound"
+     *     )
+     * )
+     */
     public function destroy(Card $card): Response
     {
         $this->authorize('delete', $card);

--- a/app/Http/Controllers/CardController.php
+++ b/app/Http/Controllers/CardController.php
@@ -8,6 +8,7 @@ use App\Services\CardService;
 use App\Services\ColumnService;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
+use OpenApi\Annotations as OA;
 use Symfony\Component\HttpFoundation\Response;
 
 class CardController extends Controller

--- a/app/Http/Controllers/CardController.php
+++ b/app/Http/Controllers/CardController.php
@@ -19,7 +19,7 @@ class CardController extends Controller
      * @OA\Post(
      *     path="/api/v1/cards",
      *     summary="Create a card",
-     *     tags={"Cards"},
+     *     tags={"cards"},
      *
      *     @OA\RequestBody(
      *         required=true,
@@ -77,7 +77,7 @@ class CardController extends Controller
      * @OA\Get(
      *     path="/api/v1/cards/{card}",
      *     summary="Retrieve a card",
-     *     tags={"Cards"},
+     *     tags={"cards"},
      *
      *     @OA\Parameter(ref="#/components/parameters/CardIdParam"),
      *
@@ -113,7 +113,7 @@ class CardController extends Controller
      * @OA\Patch(
      *     path="/api/v1/cards/{card}/title",
      *     summary="Update a card title",
-     *     tags={"Cards"},
+     *     tags={"cards"},
      *
      *     @OA\Parameter(ref="#/components/parameters/CardIdParam"),
      *
@@ -168,7 +168,7 @@ class CardController extends Controller
      * @OA\Patch(
      *     path="/api/v1/cards/{card}/status",
      *     summary="Update a card status",
-     *     tags={"Cards"},
+     *     tags={"cards"},
      *
      *     @OA\Parameter(ref="#/components/parameters/CardIdParam"),
      *
@@ -220,7 +220,7 @@ class CardController extends Controller
      * @OA\Patch(
      *     path="/api/v1/cards/{card}/position",
      *     summary="Move a card to a different position or month",
-     *     tags={"Cards"},
+     *     tags={"cards"},
      *
      *     @OA\Parameter(ref="#/components/parameters/CardIdParam"),
      *
@@ -272,7 +272,7 @@ class CardController extends Controller
      * @OA\Delete(
      *     path="/api/v1/cards/{card}",
      *     summary="Delete a card",
-     *     tags={"Cards"},
+     *     tags={"cards"},
      *
      *     @OA\Parameter(ref="#/components/parameters/CardIdParam"),
      *

--- a/app/Http/Controllers/CardController.php
+++ b/app/Http/Controllers/CardController.php
@@ -20,20 +20,27 @@ class CardController extends Controller
      *     path="/api/v1/cards",
      *     summary="Create a card",
      *     tags={"Cards"},
+     *
      *     @OA\RequestBody(
      *         required=true,
+     *
      *         @OA\JsonContent(ref="#/components/schemas/CreateCardRequest")
      *     ),
+     *
      *     @OA\Response(
      *         response=201,
      *         description="Card created",
+     *
      *         @OA\Header(
      *             header="Location",
      *             description="URL to the newly created card resource",
+     *
      *             @OA\Schema(type="string", format="uri")
      *         ),
+     *
      *         @OA\JsonContent(ref="#/components/schemas/Card")
      *     ),
+     *
      *     @OA\Response(
      *         response=401,
      *         ref="#/components/responses/Unauthenticated"
@@ -71,12 +78,16 @@ class CardController extends Controller
      *     path="/api/v1/cards/{card}",
      *     summary="Retrieve a card",
      *     tags={"Cards"},
+     *
      *     @OA\Parameter(ref="#/components/parameters/CardIdParam"),
+     *
      *     @OA\Response(
      *         response=200,
      *         description="Card details",
+     *
      *         @OA\JsonContent(ref="#/components/schemas/CardWithColumn")
      *     ),
+     *
      *     @OA\Response(
      *         response=401,
      *         ref="#/components/responses/Unauthenticated"
@@ -103,16 +114,22 @@ class CardController extends Controller
      *     path="/api/v1/cards/{card}/title",
      *     summary="Update a card title",
      *     tags={"Cards"},
+     *
      *     @OA\Parameter(ref="#/components/parameters/CardIdParam"),
+     *
      *     @OA\RequestBody(
      *         required=true,
+     *
      *         @OA\JsonContent(ref="#/components/schemas/UpdateTitleRequest")
      *     ),
+     *
      *     @OA\Response(
      *         response=200,
      *         description="Updated card",
+     *
      *         @OA\JsonContent(ref="#/components/schemas/CardWithColumn")
      *     ),
+     *
      *     @OA\Response(
      *         response=401,
      *         ref="#/components/responses/Unauthenticated"
@@ -152,16 +169,22 @@ class CardController extends Controller
      *     path="/api/v1/cards/{card}/status",
      *     summary="Update a card status",
      *     tags={"Cards"},
+     *
      *     @OA\Parameter(ref="#/components/parameters/CardIdParam"),
+     *
      *     @OA\RequestBody(
      *         required=true,
+     *
      *         @OA\JsonContent(ref="#/components/schemas/UpdateStatusRequest")
      *     ),
+     *
      *     @OA\Response(
      *         response=200,
      *         description="Updated card",
+     *
      *         @OA\JsonContent(ref="#/components/schemas/CardWithColumn")
      *     ),
+     *
      *     @OA\Response(
      *         response=401,
      *         ref="#/components/responses/Unauthenticated"
@@ -198,16 +221,22 @@ class CardController extends Controller
      *     path="/api/v1/cards/{card}/position",
      *     summary="Move a card to a different position or month",
      *     tags={"Cards"},
+     *
      *     @OA\Parameter(ref="#/components/parameters/CardIdParam"),
+     *
      *     @OA\RequestBody(
      *         required=true,
+     *
      *         @OA\JsonContent(ref="#/components/schemas/UpdatePositionRequest")
      *     ),
+     *
      *     @OA\Response(
      *         response=200,
      *         description="Updated card",
+     *
      *         @OA\JsonContent(ref="#/components/schemas/CardWithColumn")
      *     ),
+     *
      *     @OA\Response(
      *         response=401,
      *         ref="#/components/responses/Unauthenticated"
@@ -244,12 +273,16 @@ class CardController extends Controller
      *     path="/api/v1/cards/{card}",
      *     summary="Delete a card",
      *     tags={"Cards"},
+     *
      *     @OA\Parameter(ref="#/components/parameters/CardIdParam"),
+     *
      *     @OA\Response(
      *         response=204,
      *         description="Card deleted",
+     *
      *         @OA\JsonContent(type="object", example={})
      *     ),
+     *
      *     @OA\Response(
      *         response=401,
      *         ref="#/components/responses/Unauthenticated"

--- a/app/Http/Controllers/ColumnController.php
+++ b/app/Http/Controllers/ColumnController.php
@@ -17,13 +17,17 @@ class ColumnController extends Controller
      *     summary="List cards for a month",
      *     description="Retrieve a column (creating it if it does not yet exist) and list its cards ordered by position.",
      *     tags={"Columns", "Cards"},
+     *
      *     @OA\Parameter(ref="#/components/parameters/YearParam"),
      *     @OA\Parameter(ref="#/components/parameters/MonthParam"),
+     *
      *     @OA\Response(
      *         response=200,
      *         description="Column with cards",
+     *
      *         @OA\JsonContent(ref="#/components/schemas/ColumnWithCardsResponse")
      *     ),
+     *
      *     @OA\Response(
      *         response=401,
      *         ref="#/components/responses/Unauthenticated"

--- a/app/Http/Controllers/ColumnController.php
+++ b/app/Http/Controllers/ColumnController.php
@@ -16,7 +16,7 @@ class ColumnController extends Controller
      *     path="/api/v1/columns/{year}/{month}/cards",
      *     summary="List cards for a month",
      *     description="Retrieve a column (creating it if it does not yet exist) and list its cards ordered by position.",
-     *     tags={"Columns", "Cards"},
+     *     tags={"columns", "cards"},
      *
      *     @OA\Parameter(ref="#/components/parameters/YearParam"),
      *     @OA\Parameter(ref="#/components/parameters/MonthParam"),

--- a/app/Http/Controllers/ColumnController.php
+++ b/app/Http/Controllers/ColumnController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Http\Requests\YearMonthRequest;
 use App\Services\ColumnService;
 use Illuminate\Http\JsonResponse;
+use OpenApi\Annotations as OA;
 
 class ColumnController extends Controller
 {

--- a/app/Http/Controllers/ColumnController.php
+++ b/app/Http/Controllers/ColumnController.php
@@ -10,6 +10,25 @@ class ColumnController extends Controller
 {
     public function __construct(private ColumnService $columns) {}
 
+    /**
+     * @OA\Get(
+     *     path="/api/v1/columns/{year}/{month}/cards",
+     *     summary="List cards for a month",
+     *     description="Retrieve a column (creating it if it does not yet exist) and list its cards ordered by position.",
+     *     tags={"Columns", "Cards"},
+     *     @OA\Parameter(ref="#/components/parameters/YearParam"),
+     *     @OA\Parameter(ref="#/components/parameters/MonthParam"),
+     *     @OA\Response(
+     *         response=200,
+     *         description="Column with cards",
+     *         @OA\JsonContent(ref="#/components/schemas/ColumnWithCardsResponse")
+     *     ),
+     *     @OA\Response(
+     *         response=401,
+     *         ref="#/components/responses/Unauthenticated"
+     *     )
+     * )
+     */
     public function cards(YearMonthRequest $request): JsonResponse
     {
         $data = $request->validated();

--- a/app/OpenApi/OpenApiComponents.php
+++ b/app/OpenApi/OpenApiComponents.php
@@ -1,0 +1,226 @@
+<?php
+
+namespace App\OpenApi;
+
+use OpenApi\Annotations as OA;
+
+/**
+ * @OA\Schema(
+ *     schema="RegisterRequest",
+ *     type="object",
+ *     required={"name","email","password"},
+ *     @OA\Property(property="name", type="string", maxLength=255),
+ *     @OA\Property(property="email", type="string", format="email", description="Must be unique among users."),
+ *     @OA\Property(property="password", type="string", minLength=8, format="password")
+ * )
+ *
+ * @OA\Schema(
+ *     schema="LoginRequest",
+ *     type="object",
+ *     required={"email","password"},
+ *     @OA\Property(property="email", type="string", format="email"),
+ *     @OA\Property(property="password", type="string", format="password")
+ * )
+ *
+ * @OA\Schema(
+ *     schema="AuthTokenResponse",
+ *     type="object",
+ *     required={"token","user"},
+ *     @OA\Property(property="token", type="string", description="Bearer token to use in the Authorization header."),
+ *     @OA\Property(property="user", ref="#/components/schemas/AuthUserSummary")
+ * )
+ *
+ * @OA\Schema(
+ *     schema="AuthUserSummary",
+ *     type="object",
+ *     required={"id","email"},
+ *     @OA\Property(property="id", type="integer"),
+ *     @OA\Property(property="email", type="string", format="email")
+ * )
+ *
+ * @OA\Schema(
+ *     schema="MessageResponse",
+ *     type="object",
+ *     required={"message"},
+ *     @OA\Property(property="message", type="string")
+ * )
+ *
+ * @OA\Schema(
+ *     schema="UserProfile",
+ *     type="object",
+ *     required={"id","name","email","created_at","updated_at"},
+ *     @OA\Property(property="id", type="integer"),
+ *     @OA\Property(property="name", type="string"),
+ *     @OA\Property(property="email", type="string", format="email"),
+ *     @OA\Property(property="email_verified_at", type="string", format="date-time", nullable=true),
+ *     @OA\Property(property="created_at", type="string", format="date-time"),
+ *     @OA\Property(property="updated_at", type="string", format="date-time")
+ * )
+ *
+ * @OA\Schema(
+ *     schema="Column",
+ *     type="object",
+ *     required={"id","year","month","user_id"},
+ *     @OA\Property(property="id", type="integer"),
+ *     @OA\Property(property="year", type="integer", minimum=2000, maximum=4000),
+ *     @OA\Property(property="month", type="integer", minimum=1, maximum=12),
+ *     @OA\Property(property="user_id", type="integer"),
+ *     @OA\Property(property="created_at", type="string", format="date-time", nullable=true),
+ *     @OA\Property(property="updated_at", type="string", format="date-time", nullable=true)
+ * )
+ *
+ * @OA\Schema(
+ *     schema="Card",
+ *     type="object",
+ *     required={"id","column_id","order","title","status"},
+ *     @OA\Property(property="id", type="integer"),
+ *     @OA\Property(property="column_id", type="integer"),
+ *     @OA\Property(property="order", type="integer", minimum=1),
+ *     @OA\Property(property="title", type="string"),
+ *     @OA\Property(property="status", type="string", enum={"not_started","in_progress","completed"}),
+ *     @OA\Property(property="created_at", type="string", format="date-time", nullable=true),
+ *     @OA\Property(property="updated_at", type="string", format="date-time", nullable=true)
+ * )
+ *
+ * @OA\Schema(
+ *     schema="CardWithColumn",
+ *     allOf={
+ *         @OA\Schema(ref="#/components/schemas/Card"),
+ *         @OA\Schema(
+ *             type="object",
+ *             @OA\Property(property="column", ref="#/components/schemas/Column")
+ *         )
+ *     }
+ * )
+ *
+ * @OA\Schema(
+ *     schema="ColumnWithCardsResponse",
+ *     type="object",
+ *     required={"column","cards"},
+ *     @OA\Property(property="column", ref="#/components/schemas/Column"),
+ *     @OA\Property(
+ *         property="cards",
+ *         type="array",
+ *         @OA\Items(ref="#/components/schemas/Card")
+ *     )
+ * )
+ *
+ * @OA\Schema(
+ *     schema="CreateCardRequest",
+ *     type="object",
+ *     required={"column_id","order"},
+ *     @OA\Property(property="column_id", type="integer", description="Must reference an existing column."),
+ *     @OA\Property(property="order", type="integer", minimum=1),
+ *     @OA\Property(property="title", type="string", nullable=true, description="Defaults to an empty string when omitted.")
+ * )
+ *
+ * @OA\Schema(
+ *     schema="UpdateTitleRequest",
+ *     type="object",
+ *     required={"title"},
+ *     @OA\Property(property="title", type="string", minLength=0, maxLength=255)
+ * )
+ *
+ * @OA\Schema(
+ *     schema="UpdateStatusRequest",
+ *     type="object",
+ *     required={"status"},
+ *     @OA\Property(property="status", type="string", enum={"not_started","in_progress","completed"})
+ * )
+ *
+ * @OA\Schema(
+ *     schema="UpdatePositionRequest",
+ *     type="object",
+ *     required={"year","month","order"},
+ *     @OA\Property(property="year", type="integer", minimum=2000, maximum=4000),
+ *     @OA\Property(property="month", type="integer", minimum=1, maximum=12),
+ *     @OA\Property(property="order", type="integer", minimum=1)
+ * )
+ *
+ * @OA\Schema(
+ *     schema="ErrorMessage",
+ *     type="object",
+ *     required={"message"},
+ *     @OA\Property(property="message", type="string")
+ * )
+ *
+ * @OA\Schema(
+ *     schema="ValidationErrors",
+ *     type="object",
+ *     additionalProperties=@OA\Schema(type="array", @OA\Items(type="string"))
+ * )
+ *
+ * @OA\Schema(
+ *     schema="ValidationErrorResponse",
+ *     type="object",
+ *     required={"message","errors"},
+ *     @OA\Property(property="message", type="string"),
+ *     @OA\Property(property="errors", ref="#/components/schemas/ValidationErrors")
+ * )
+ *
+ * @OA\Parameter(
+ *     parameter="YearParam",
+ *     name="year",
+ *     in="path",
+ *     required=true,
+ *     description="Target year for the column.",
+ *     @OA\Schema(type="integer", minimum=2000, maximum=4000)
+ * )
+ *
+ * @OA\Parameter(
+ *     parameter="MonthParam",
+ *     name="month",
+ *     in="path",
+ *     required=true,
+ *     description="Target month for the column.",
+ *     @OA\Schema(type="integer", minimum=1, maximum=12)
+ * )
+ *
+ * @OA\Parameter(
+ *     parameter="CardIdParam",
+ *     name="card",
+ *     in="path",
+ *     required=true,
+ *     description="Identifier of the card.",
+ *     @OA\Schema(type="integer", minimum=1)
+ * )
+ *
+ * @OA\Response(
+ *     response="Unauthenticated",
+ *     description="Authentication required",
+ *     @OA\JsonContent(ref="#/components/schemas/ErrorMessage")
+ * )
+ *
+ * @OA\Response(
+ *     response="Forbidden",
+ *     description="Action is not authorized for the current user",
+ *     @OA\JsonContent(ref="#/components/schemas/ErrorMessage")
+ * )
+ *
+ * @OA\Response(
+ *     response="NotFound",
+ *     description="Resource not found",
+ *     @OA\JsonContent(ref="#/components/schemas/ErrorMessage")
+ * )
+ *
+ * @OA\Response(
+ *     response="ValidationError",
+ *     description="Validation failed",
+ *     @OA\JsonContent(ref="#/components/schemas/ValidationErrorResponse")
+ * )
+ *
+ * @OA\SecurityScheme(
+ *     securityScheme="SanctumToken",
+ *     type="http",
+ *     scheme="bearer",
+ *     bearerFormat="Sanctum"
+ * )
+ *
+ * @OA\Server(
+ *     url="./",
+ *     description="Relative base path for the API"
+ * )
+ */
+class OpenApiComponents
+{
+}

--- a/app/OpenApi/OpenApiComponents.php
+++ b/app/OpenApi/OpenApiComponents.php
@@ -5,6 +5,24 @@ namespace App\OpenApi;
 use OpenApi\Annotations as OA;
 
 /**
+ * @OA\Info(
+ *     title="Roadmap API",
+ *     version="1.0.0",
+ *     description="OpenAPI specification for the Roadmap backend.\nAll endpoints are prefixed with `/api/v1`."
+ * )
+ *
+ * @OA\Server(
+ *     url="./",
+ *     description="Relative base path for the API"
+ * )
+ *
+ * @OA\SecurityScheme(
+ *     securityScheme="SanctumToken",
+ *     type="http",
+ *     scheme="bearer",
+ *     bearerFormat="Sanctum"
+ * )
+ *
  * @OA\Schema(
  *     schema="RegisterRequest",
  *     type="object",
@@ -147,7 +165,10 @@ use OpenApi\Annotations as OA;
  * @OA\Schema(
  *     schema="ValidationErrors",
  *     type="object",
- *     additionalProperties=@OA\Schema(type="array", @OA\Items(type="string"))
+ *     additionalProperties={
+ *         "type": "array",
+ *         "items": {"type": "string"}
+ *     }
  * )
  *
  * @OA\Schema(
@@ -207,18 +228,6 @@ use OpenApi\Annotations as OA;
  *     response="ValidationError",
  *     description="Validation failed",
  *     @OA\JsonContent(ref="#/components/schemas/ValidationErrorResponse")
- * )
- *
- * @OA\SecurityScheme(
- *     securityScheme="SanctumToken",
- *     type="http",
- *     scheme="bearer",
- *     bearerFormat="Sanctum"
- * )
- *
- * @OA\Server(
- *     url="./",
- *     description="Relative base path for the API"
  * )
  */
 class OpenApiComponents

--- a/app/OpenApi/OpenApiComponents.php
+++ b/app/OpenApi/OpenApiComponents.php
@@ -27,6 +27,7 @@ use OpenApi\Annotations as OA;
  *     schema="RegisterRequest",
  *     type="object",
  *     required={"name","email","password"},
+ *
  *     @OA\Property(property="name", type="string", maxLength=255),
  *     @OA\Property(property="email", type="string", format="email", description="Must be unique among users."),
  *     @OA\Property(property="password", type="string", minLength=8, format="password")
@@ -36,6 +37,7 @@ use OpenApi\Annotations as OA;
  *     schema="LoginRequest",
  *     type="object",
  *     required={"email","password"},
+ *
  *     @OA\Property(property="email", type="string", format="email"),
  *     @OA\Property(property="password", type="string", format="password")
  * )
@@ -44,6 +46,7 @@ use OpenApi\Annotations as OA;
  *     schema="AuthTokenResponse",
  *     type="object",
  *     required={"token","user"},
+ *
  *     @OA\Property(property="token", type="string", description="Bearer token to use in the Authorization header."),
  *     @OA\Property(property="user", ref="#/components/schemas/AuthUserSummary")
  * )
@@ -52,6 +55,7 @@ use OpenApi\Annotations as OA;
  *     schema="AuthUserSummary",
  *     type="object",
  *     required={"id","email"},
+ *
  *     @OA\Property(property="id", type="integer"),
  *     @OA\Property(property="email", type="string", format="email")
  * )
@@ -60,6 +64,7 @@ use OpenApi\Annotations as OA;
  *     schema="MessageResponse",
  *     type="object",
  *     required={"message"},
+ *
  *     @OA\Property(property="message", type="string")
  * )
  *
@@ -67,6 +72,7 @@ use OpenApi\Annotations as OA;
  *     schema="UserProfile",
  *     type="object",
  *     required={"id","name","email","created_at","updated_at"},
+ *
  *     @OA\Property(property="id", type="integer"),
  *     @OA\Property(property="name", type="string"),
  *     @OA\Property(property="email", type="string", format="email"),
@@ -79,6 +85,7 @@ use OpenApi\Annotations as OA;
  *     schema="Column",
  *     type="object",
  *     required={"id","year","month","user_id"},
+ *
  *     @OA\Property(property="id", type="integer"),
  *     @OA\Property(property="year", type="integer", minimum=2000, maximum=4000),
  *     @OA\Property(property="month", type="integer", minimum=1, maximum=12),
@@ -91,6 +98,7 @@ use OpenApi\Annotations as OA;
  *     schema="Card",
  *     type="object",
  *     required={"id","column_id","order","title","status"},
+ *
  *     @OA\Property(property="id", type="integer"),
  *     @OA\Property(property="column_id", type="integer"),
  *     @OA\Property(property="order", type="integer", minimum=1),
@@ -106,6 +114,7 @@ use OpenApi\Annotations as OA;
  *         @OA\Schema(ref="#/components/schemas/Card"),
  *         @OA\Schema(
  *             type="object",
+ *
  *             @OA\Property(property="column", ref="#/components/schemas/Column")
  *         )
  *     }
@@ -115,10 +124,12 @@ use OpenApi\Annotations as OA;
  *     schema="ColumnWithCardsResponse",
  *     type="object",
  *     required={"column","cards"},
+ *
  *     @OA\Property(property="column", ref="#/components/schemas/Column"),
  *     @OA\Property(
  *         property="cards",
  *         type="array",
+ *
  *         @OA\Items(ref="#/components/schemas/Card")
  *     )
  * )
@@ -127,6 +138,7 @@ use OpenApi\Annotations as OA;
  *     schema="CreateCardRequest",
  *     type="object",
  *     required={"column_id","order"},
+ *
  *     @OA\Property(property="column_id", type="integer", description="Must reference an existing column."),
  *     @OA\Property(property="order", type="integer", minimum=1),
  *     @OA\Property(property="title", type="string", nullable=true, description="Defaults to an empty string when omitted.")
@@ -136,6 +148,7 @@ use OpenApi\Annotations as OA;
  *     schema="UpdateTitleRequest",
  *     type="object",
  *     required={"title"},
+ *
  *     @OA\Property(property="title", type="string", minLength=0, maxLength=255)
  * )
  *
@@ -143,6 +156,7 @@ use OpenApi\Annotations as OA;
  *     schema="UpdateStatusRequest",
  *     type="object",
  *     required={"status"},
+ *
  *     @OA\Property(property="status", type="string", enum={"not_started","in_progress","completed"})
  * )
  *
@@ -150,6 +164,7 @@ use OpenApi\Annotations as OA;
  *     schema="UpdatePositionRequest",
  *     type="object",
  *     required={"year","month","order"},
+ *
  *     @OA\Property(property="year", type="integer", minimum=2000, maximum=4000),
  *     @OA\Property(property="month", type="integer", minimum=1, maximum=12),
  *     @OA\Property(property="order", type="integer", minimum=1)
@@ -159,6 +174,7 @@ use OpenApi\Annotations as OA;
  *     schema="ErrorMessage",
  *     type="object",
  *     required={"message"},
+ *
  *     @OA\Property(property="message", type="string")
  * )
  *
@@ -170,11 +186,11 @@ use OpenApi\Annotations as OA;
  *         "items": {"type": "string"}
  *     }
  * )
- *
  * @OA\Schema(
  *     schema="ValidationErrorResponse",
  *     type="object",
  *     required={"message","errors"},
+ *
  *     @OA\Property(property="message", type="string"),
  *     @OA\Property(property="errors", ref="#/components/schemas/ValidationErrors")
  * )
@@ -185,6 +201,7 @@ use OpenApi\Annotations as OA;
  *     in="path",
  *     required=true,
  *     description="Target year for the column.",
+ *
  *     @OA\Schema(type="integer", minimum=2000, maximum=4000)
  * )
  *
@@ -194,6 +211,7 @@ use OpenApi\Annotations as OA;
  *     in="path",
  *     required=true,
  *     description="Target month for the column.",
+ *
  *     @OA\Schema(type="integer", minimum=1, maximum=12)
  * )
  *
@@ -203,33 +221,36 @@ use OpenApi\Annotations as OA;
  *     in="path",
  *     required=true,
  *     description="Identifier of the card.",
+ *
  *     @OA\Schema(type="integer", minimum=1)
  * )
  *
  * @OA\Response(
  *     response="Unauthenticated",
  *     description="Authentication required",
+ *
  *     @OA\JsonContent(ref="#/components/schemas/ErrorMessage")
  * )
  *
  * @OA\Response(
  *     response="Forbidden",
  *     description="Action is not authorized for the current user",
+ *
  *     @OA\JsonContent(ref="#/components/schemas/ErrorMessage")
  * )
  *
  * @OA\Response(
  *     response="NotFound",
  *     description="Resource not found",
+ *
  *     @OA\JsonContent(ref="#/components/schemas/ErrorMessage")
  * )
  *
  * @OA\Response(
  *     response="ValidationError",
  *     description="Validation failed",
+ *
  *     @OA\JsonContent(ref="#/components/schemas/ValidationErrorResponse")
  * )
  */
-class OpenApiComponents
-{
-}
+class OpenApiComponents {}

--- a/config/l5-swagger.php
+++ b/config/l5-swagger.php
@@ -5,7 +5,15 @@ return [
     'documentations' => [
         'default' => [
             'api' => [
-                'title' => 'L5 Swagger UI',
+                'title' => 'Roadmap API',
+                'description' => "OpenAPI specification for the Roadmap backend.\nAll endpoints are prefixed with `/api/v1`.",
+                'version' => '1.0.0',
+            ],
+            'servers' => [
+                [
+                    'url' => './',
+                    'description' => 'Relative base path for the API',
+                ],
             ],
 
             'routes' => [
@@ -162,7 +170,7 @@ return [
              * Allows to generate specs either for OpenAPI 3.0.0 or OpenAPI 3.1.0.
              * By default the spec will be in version 3.0.0
              */
-            'open_api_spec_version' => env('L5_SWAGGER_OPEN_API_SPEC_VERSION', \L5Swagger\Generator::OPEN_API_DEFAULT_SPEC_VERSION),
+            'open_api_spec_version' => env('L5_SWAGGER_OPEN_API_SPEC_VERSION', '3.1.0'),
         ],
 
         /*
@@ -170,65 +178,15 @@ return [
         */
         'securityDefinitions' => [
             'securitySchemes' => [
-                /*
-                 * Examples of Security schemes
-                 */
-                /*
-                'api_key_security_example' => [ // Unique name of security
-                    'type' => 'apiKey', // The type of the security scheme. Valid values are "basic", "apiKey" or "oauth2".
-                    'description' => 'A short description for security scheme',
-                    'name' => 'api_key', // The name of the header or query parameter to be used.
-                    'in' => 'header', // The location of the API key. Valid values are "query" or "header".
+                'SanctumToken' => [
+                    'type' => 'http',
+                    'scheme' => 'bearer',
+                    'bearerFormat' => 'Sanctum',
                 ],
-                'oauth2_security_example' => [ // Unique name of security
-                    'type' => 'oauth2', // The type of the security scheme. Valid values are "basic", "apiKey" or "oauth2".
-                    'description' => 'A short description for oauth2 security scheme.',
-                    'flow' => 'implicit', // The flow used by the OAuth2 security scheme. Valid values are "implicit", "password", "application" or "accessCode".
-                    'authorizationUrl' => 'http://example.com/auth', // The authorization URL to be used for (implicit/accessCode)
-                    //'tokenUrl' => 'http://example.com/auth' // The authorization URL to be used for (password/application/accessCode)
-                    'scopes' => [
-                        'read:projects' => 'read your projects',
-                        'write:projects' => 'modify projects in your account',
-                    ]
-                ],
-                */
-
-                /* Open API 3.0 support
-                'passport' => [ // Unique name of security
-                    'type' => 'oauth2', // The type of the security scheme. Valid values are "basic", "apiKey" or "oauth2".
-                    'description' => 'Laravel passport oauth2 security.',
-                    'in' => 'header',
-                    'scheme' => 'https',
-                    'flows' => [
-                        "password" => [
-                            "authorizationUrl" => config('app.url') . '/oauth/authorize',
-                            "tokenUrl" => config('app.url') . '/oauth/token',
-                            "refreshUrl" => config('app.url') . '/token/refresh',
-                            "scopes" => []
-                        ],
-                    ],
-                ],
-                'sanctum' => [ // Unique name of security
-                    'type' => 'apiKey', // Valid values are "basic", "apiKey" or "oauth2".
-                    'description' => 'Enter token in format (Bearer <token>)',
-                    'name' => 'Authorization', // The name of the header or query parameter to be used.
-                    'in' => 'header', // The location of the API key. Valid values are "query" or "header".
-                ],
-                */
             ],
             'security' => [
-                /*
-                 * Examples of Securities
-                 */
                 [
-                    /*
-                    'oauth2_security_example' => [
-                        'read',
-                        'write'
-                    ],
-
-                    'passport' => []
-                    */
+                    'SanctumToken' => [],
                 ],
             ],
         ],

--- a/config/l5-swagger.php
+++ b/config/l5-swagger.php
@@ -4,18 +4,6 @@ return [
     'default' => 'default',
     'documentations' => [
         'default' => [
-            'api' => [
-                'title' => 'Roadmap API',
-                'description' => "OpenAPI specification for the Roadmap backend.\nAll endpoints are prefixed with `/api/v1`.",
-                'version' => '1.0.0',
-            ],
-            'servers' => [
-                [
-                    'url' => './',
-                    'description' => 'Relative base path for the API',
-                ],
-            ],
-
             'routes' => [
                 /*
                  * Route for accessing api documentation interface
@@ -174,20 +162,12 @@ return [
         ],
 
         /*
-         * API security definitions. Will be generated into documentation file.
-        */
+         * API security definitions. Required to prevent template errors.
+         * Actual security schemes are defined in OpenAPI annotations.
+         */
         'securityDefinitions' => [
             'securitySchemes' => [
-                'SanctumToken' => [
-                    'type' => 'http',
-                    'scheme' => 'bearer',
-                    'bearerFormat' => 'Sanctum',
-                ],
-            ],
-            'security' => [
-                [
-                    'SanctumToken' => [],
-                ],
+                // Empty - security schemes are defined in annotations
             ],
         ],
 

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -15,7 +15,7 @@
         "/api/v1/register": {
             "post": {
                 "tags": [
-                    "Auth"
+                    "auth"
                 ],
                 "summary": "Register a new user",
                 "description": "Create a new user account and issue an API token.",
@@ -53,7 +53,7 @@
         "/api/v1/login": {
             "post": {
                 "tags": [
-                    "Auth"
+                    "auth"
                 ],
                 "summary": "Authenticate a user",
                 "description": "Issue a Sanctum API token for an existing user.",
@@ -101,7 +101,7 @@
         "/api/v1/logout": {
             "post": {
                 "tags": [
-                    "Auth"
+                    "auth"
                 ],
                 "summary": "Revoke the current token",
                 "description": "Revoke current token.",
@@ -126,7 +126,7 @@
         "/api/v1/user": {
             "get": {
                 "tags": [
-                    "Auth"
+                    "auth"
                 ],
                 "summary": "Retrieve the authenticated user profile",
                 "description": "Return authenticated user profile.",
@@ -151,7 +151,7 @@
         "/api/v1/ping-auth": {
             "get": {
                 "tags": [
-                    "Auth"
+                    "auth"
                 ],
                 "summary": "Authenticated ping endpoint",
                 "description": "Return authenticated pong message.",
@@ -176,7 +176,7 @@
         "/api/v1/cards": {
             "post": {
                 "tags": [
-                    "Cards"
+                    "cards"
                 ],
                 "summary": "Create a card",
                 "operationId": "61e21287a78dfdbf61488bfcbfb1df39",
@@ -225,7 +225,7 @@
         "/api/v1/cards/{card}": {
             "get": {
                 "tags": [
-                    "Cards"
+                    "cards"
                 ],
                 "summary": "Retrieve a card",
                 "operationId": "5c909e72f4f8cefcf2cdc7aeb6dcb2b3",
@@ -258,7 +258,7 @@
             },
             "delete": {
                 "tags": [
-                    "Cards"
+                    "cards"
                 ],
                 "summary": "Delete a card",
                 "operationId": "4d24e63d8dd481e2ef9994a8f9ce2732",
@@ -294,7 +294,7 @@
         "/api/v1/cards/{card}/title": {
             "patch": {
                 "tags": [
-                    "Cards"
+                    "cards"
                 ],
                 "summary": "Update a card title",
                 "operationId": "4abac1529369b18351b3ab429f16c3d9",
@@ -342,7 +342,7 @@
         "/api/v1/cards/{card}/status": {
             "patch": {
                 "tags": [
-                    "Cards"
+                    "cards"
                 ],
                 "summary": "Update a card status",
                 "operationId": "980906442e42c589feaa60fe19db2a98",
@@ -390,7 +390,7 @@
         "/api/v1/cards/{card}/position": {
             "patch": {
                 "tags": [
-                    "Cards"
+                    "cards"
                 ],
                 "summary": "Move a card to a different position or month",
                 "operationId": "6b8addaa57f7afdf91404814017ea2de",
@@ -438,8 +438,8 @@
         "/api/v1/columns/{year}/{month}/cards": {
             "get": {
                 "tags": [
-                    "Columns",
-                    "Cards"
+                    "columns",
+                    "cards"
                 ],
                 "summary": "List cards for a month",
                 "description": "Retrieve a column (creating it if it does not yet exist) and list its cards ordered by position.",
@@ -913,16 +913,16 @@
     },
     "tags": [
         {
-            "name": "Auth",
-            "description": "Auth"
+            "name": "auth",
+            "description": "auth"
         },
         {
-            "name": "Cards",
-            "description": "Cards"
+            "name": "cards",
+            "description": "cards"
         },
         {
-            "name": "Columns",
-            "description": "Columns"
+            "name": "columns",
+            "description": "columns"
         }
     ]
 }

--- a/storage/api-docs/api-docs.json
+++ b/storage/api-docs/api-docs.json
@@ -1,0 +1,928 @@
+{
+    "openapi": "3.1.0",
+    "info": {
+        "title": "Roadmap API",
+        "description": "OpenAPI specification for the Roadmap backend.\\nAll endpoints are prefixed with `/api/v1`.",
+        "version": "1.0.0"
+    },
+    "servers": [
+        {
+            "url": "./",
+            "description": "Relative base path for the API"
+        }
+    ],
+    "paths": {
+        "/api/v1/register": {
+            "post": {
+                "tags": [
+                    "Auth"
+                ],
+                "summary": "Register a new user",
+                "description": "Create a new user account and issue an API token.",
+                "operationId": "6796c44e1f6079c411abbfed066c5907",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/RegisterRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "User registered successfully",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AuthTokenResponse"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "$ref": "#/components/responses/ValidationError"
+                    }
+                },
+                "security": [
+                    {}
+                ]
+            }
+        },
+        "/api/v1/login": {
+            "post": {
+                "tags": [
+                    "Auth"
+                ],
+                "summary": "Authenticate a user",
+                "description": "Issue a Sanctum API token for an existing user.",
+                "operationId": "da2ca4d7a5cdec77b8b45a20373535cb",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/LoginRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Authentication successful",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/AuthTokenResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Invalid credentials",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ErrorMessage"
+                                }
+                            }
+                        }
+                    },
+                    "422": {
+                        "$ref": "#/components/responses/ValidationError"
+                    }
+                },
+                "security": [
+                    {}
+                ]
+            }
+        },
+        "/api/v1/logout": {
+            "post": {
+                "tags": [
+                    "Auth"
+                ],
+                "summary": "Revoke the current token",
+                "description": "Revoke current token.",
+                "operationId": "c4eddaf1a2e990cc90e4326c0d731d41",
+                "responses": {
+                    "200": {
+                        "description": "Logout confirmation",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MessageResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/Unauthenticated"
+                    }
+                }
+            }
+        },
+        "/api/v1/user": {
+            "get": {
+                "tags": [
+                    "Auth"
+                ],
+                "summary": "Retrieve the authenticated user profile",
+                "description": "Return authenticated user profile.",
+                "operationId": "6804f9f92bfdc4d8fe300f2c5cc35d19",
+                "responses": {
+                    "200": {
+                        "description": "Authenticated user profile",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/UserProfile"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/Unauthenticated"
+                    }
+                }
+            }
+        },
+        "/api/v1/ping-auth": {
+            "get": {
+                "tags": [
+                    "Auth"
+                ],
+                "summary": "Authenticated ping endpoint",
+                "description": "Return authenticated pong message.",
+                "operationId": "b76c746cf528bf81c0debd53965628aa",
+                "responses": {
+                    "200": {
+                        "description": "Authenticated pong message",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/MessageResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/Unauthenticated"
+                    }
+                }
+            }
+        },
+        "/api/v1/cards": {
+            "post": {
+                "tags": [
+                    "Cards"
+                ],
+                "summary": "Create a card",
+                "operationId": "61e21287a78dfdbf61488bfcbfb1df39",
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/CreateCardRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Card created",
+                        "headers": {
+                            "Location": {
+                                "description": "URL to the newly created card resource",
+                                "schema": {
+                                    "type": "string",
+                                    "format": "uri"
+                                }
+                            }
+                        },
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/Card"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/Unauthenticated"
+                    },
+                    "403": {
+                        "$ref": "#/components/responses/Forbidden"
+                    },
+                    "422": {
+                        "$ref": "#/components/responses/ValidationError"
+                    }
+                }
+            }
+        },
+        "/api/v1/cards/{card}": {
+            "get": {
+                "tags": [
+                    "Cards"
+                ],
+                "summary": "Retrieve a card",
+                "operationId": "5c909e72f4f8cefcf2cdc7aeb6dcb2b3",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/CardIdParam"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Card details",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CardWithColumn"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/Unauthenticated"
+                    },
+                    "403": {
+                        "$ref": "#/components/responses/Forbidden"
+                    },
+                    "404": {
+                        "$ref": "#/components/responses/NotFound"
+                    }
+                }
+            },
+            "delete": {
+                "tags": [
+                    "Cards"
+                ],
+                "summary": "Delete a card",
+                "operationId": "4d24e63d8dd481e2ef9994a8f9ce2732",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/CardIdParam"
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "Card deleted",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "type": "object"
+                                },
+                                "example": []
+                            }
+                        }
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/Unauthenticated"
+                    },
+                    "403": {
+                        "$ref": "#/components/responses/Forbidden"
+                    },
+                    "404": {
+                        "$ref": "#/components/responses/NotFound"
+                    }
+                }
+            }
+        },
+        "/api/v1/cards/{card}/title": {
+            "patch": {
+                "tags": [
+                    "Cards"
+                ],
+                "summary": "Update a card title",
+                "operationId": "4abac1529369b18351b3ab429f16c3d9",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/CardIdParam"
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdateTitleRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Updated card",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CardWithColumn"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/Unauthenticated"
+                    },
+                    "403": {
+                        "$ref": "#/components/responses/Forbidden"
+                    },
+                    "404": {
+                        "$ref": "#/components/responses/NotFound"
+                    },
+                    "422": {
+                        "$ref": "#/components/responses/ValidationError"
+                    }
+                }
+            }
+        },
+        "/api/v1/cards/{card}/status": {
+            "patch": {
+                "tags": [
+                    "Cards"
+                ],
+                "summary": "Update a card status",
+                "operationId": "980906442e42c589feaa60fe19db2a98",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/CardIdParam"
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdateStatusRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Updated card",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CardWithColumn"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/Unauthenticated"
+                    },
+                    "403": {
+                        "$ref": "#/components/responses/Forbidden"
+                    },
+                    "404": {
+                        "$ref": "#/components/responses/NotFound"
+                    },
+                    "422": {
+                        "$ref": "#/components/responses/ValidationError"
+                    }
+                }
+            }
+        },
+        "/api/v1/cards/{card}/position": {
+            "patch": {
+                "tags": [
+                    "Cards"
+                ],
+                "summary": "Move a card to a different position or month",
+                "operationId": "6b8addaa57f7afdf91404814017ea2de",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/CardIdParam"
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/UpdatePositionRequest"
+                            }
+                        }
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Updated card",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/CardWithColumn"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/Unauthenticated"
+                    },
+                    "403": {
+                        "$ref": "#/components/responses/Forbidden"
+                    },
+                    "404": {
+                        "$ref": "#/components/responses/NotFound"
+                    },
+                    "422": {
+                        "$ref": "#/components/responses/ValidationError"
+                    }
+                }
+            }
+        },
+        "/api/v1/columns/{year}/{month}/cards": {
+            "get": {
+                "tags": [
+                    "Columns",
+                    "Cards"
+                ],
+                "summary": "List cards for a month",
+                "description": "Retrieve a column (creating it if it does not yet exist) and list its cards ordered by position.",
+                "operationId": "d4918ff624b5d46690b53009fc829594",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/YearParam"
+                    },
+                    {
+                        "$ref": "#/components/parameters/MonthParam"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "Column with cards",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ColumnWithCardsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/Unauthenticated"
+                    }
+                }
+            }
+        }
+    },
+    "components": {
+        "schemas": {
+            "RegisterRequest": {
+                "required": [
+                    "name",
+                    "email",
+                    "password"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "maxLength": 255
+                    },
+                    "email": {
+                        "description": "Must be unique among users.",
+                        "type": "string",
+                        "format": "email"
+                    },
+                    "password": {
+                        "type": "string",
+                        "format": "password",
+                        "minLength": 8
+                    }
+                },
+                "type": "object"
+            },
+            "LoginRequest": {
+                "required": [
+                    "email",
+                    "password"
+                ],
+                "properties": {
+                    "email": {
+                        "type": "string",
+                        "format": "email"
+                    },
+                    "password": {
+                        "type": "string",
+                        "format": "password"
+                    }
+                },
+                "type": "object"
+            },
+            "AuthTokenResponse": {
+                "required": [
+                    "token",
+                    "user"
+                ],
+                "properties": {
+                    "token": {
+                        "description": "Bearer token to use in the Authorization header.",
+                        "type": "string"
+                    },
+                    "user": {
+                        "$ref": "#/components/schemas/AuthUserSummary"
+                    }
+                },
+                "type": "object"
+            },
+            "AuthUserSummary": {
+                "required": [
+                    "id",
+                    "email"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "integer"
+                    },
+                    "email": {
+                        "type": "string",
+                        "format": "email"
+                    }
+                },
+                "type": "object"
+            },
+            "MessageResponse": {
+                "required": [
+                    "message"
+                ],
+                "properties": {
+                    "message": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "UserProfile": {
+                "required": [
+                    "id",
+                    "name",
+                    "email",
+                    "created_at",
+                    "updated_at"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "integer"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "email": {
+                        "type": "string",
+                        "format": "email"
+                    },
+                    "email_verified_at": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "date-time"
+                    },
+                    "created_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "updated_at": {
+                        "type": "string",
+                        "format": "date-time"
+                    }
+                },
+                "type": "object"
+            },
+            "Column": {
+                "required": [
+                    "id",
+                    "year",
+                    "month",
+                    "user_id"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "integer"
+                    },
+                    "year": {
+                        "type": "integer",
+                        "maximum": 4000,
+                        "minimum": 2000
+                    },
+                    "month": {
+                        "type": "integer",
+                        "maximum": 12,
+                        "minimum": 1
+                    },
+                    "user_id": {
+                        "type": "integer"
+                    },
+                    "created_at": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "date-time"
+                    },
+                    "updated_at": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "date-time"
+                    }
+                },
+                "type": "object"
+            },
+            "Card": {
+                "required": [
+                    "id",
+                    "column_id",
+                    "order",
+                    "title",
+                    "status"
+                ],
+                "properties": {
+                    "id": {
+                        "type": "integer"
+                    },
+                    "column_id": {
+                        "type": "integer"
+                    },
+                    "order": {
+                        "type": "integer",
+                        "minimum": 1
+                    },
+                    "title": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "not_started",
+                            "in_progress",
+                            "completed"
+                        ]
+                    },
+                    "created_at": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "date-time"
+                    },
+                    "updated_at": {
+                        "type": [
+                            "string",
+                            "null"
+                        ],
+                        "format": "date-time"
+                    }
+                },
+                "type": "object"
+            },
+            "CardWithColumn": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/Card"
+                    },
+                    {
+                        "properties": {
+                            "column": {
+                                "$ref": "#/components/schemas/Column"
+                            }
+                        },
+                        "type": "object"
+                    }
+                ]
+            },
+            "ColumnWithCardsResponse": {
+                "required": [
+                    "column",
+                    "cards"
+                ],
+                "properties": {
+                    "column": {
+                        "$ref": "#/components/schemas/Column"
+                    },
+                    "cards": {
+                        "type": "array",
+                        "items": {
+                            "$ref": "#/components/schemas/Card"
+                        }
+                    }
+                },
+                "type": "object"
+            },
+            "CreateCardRequest": {
+                "required": [
+                    "column_id",
+                    "order"
+                ],
+                "properties": {
+                    "column_id": {
+                        "description": "Must reference an existing column.",
+                        "type": "integer"
+                    },
+                    "order": {
+                        "type": "integer",
+                        "minimum": 1
+                    },
+                    "title": {
+                        "description": "Defaults to an empty string when omitted.",
+                        "type": [
+                            "string",
+                            "null"
+                        ]
+                    }
+                },
+                "type": "object"
+            },
+            "UpdateTitleRequest": {
+                "required": [
+                    "title"
+                ],
+                "properties": {
+                    "title": {
+                        "type": "string",
+                        "maxLength": 255,
+                        "minLength": 0
+                    }
+                },
+                "type": "object"
+            },
+            "UpdateStatusRequest": {
+                "required": [
+                    "status"
+                ],
+                "properties": {
+                    "status": {
+                        "type": "string",
+                        "enum": [
+                            "not_started",
+                            "in_progress",
+                            "completed"
+                        ]
+                    }
+                },
+                "type": "object"
+            },
+            "UpdatePositionRequest": {
+                "required": [
+                    "year",
+                    "month",
+                    "order"
+                ],
+                "properties": {
+                    "year": {
+                        "type": "integer",
+                        "maximum": 4000,
+                        "minimum": 2000
+                    },
+                    "month": {
+                        "type": "integer",
+                        "maximum": 12,
+                        "minimum": 1
+                    },
+                    "order": {
+                        "type": "integer",
+                        "minimum": 1
+                    }
+                },
+                "type": "object"
+            },
+            "ErrorMessage": {
+                "required": [
+                    "message"
+                ],
+                "properties": {
+                    "message": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
+            },
+            "ValidationErrors": {
+                "type": "object",
+                "additionalProperties": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            },
+            "ValidationErrorResponse": {
+                "required": [
+                    "message",
+                    "errors"
+                ],
+                "properties": {
+                    "message": {
+                        "type": "string"
+                    },
+                    "errors": {
+                        "$ref": "#/components/schemas/ValidationErrors"
+                    }
+                },
+                "type": "object"
+            }
+        },
+        "responses": {
+            "Unauthenticated": {
+                "description": "Authentication required",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/ErrorMessage"
+                        }
+                    }
+                }
+            },
+            "Forbidden": {
+                "description": "Action is not authorized for the current user",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/ErrorMessage"
+                        }
+                    }
+                }
+            },
+            "NotFound": {
+                "description": "Resource not found",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/ErrorMessage"
+                        }
+                    }
+                }
+            },
+            "ValidationError": {
+                "description": "Validation failed",
+                "content": {
+                    "application/json": {
+                        "schema": {
+                            "$ref": "#/components/schemas/ValidationErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "parameters": {
+            "YearParam": {
+                "name": "year",
+                "in": "path",
+                "description": "Target year for the column.",
+                "required": true,
+                "schema": {
+                    "type": "integer",
+                    "maximum": 4000,
+                    "minimum": 2000
+                }
+            },
+            "MonthParam": {
+                "name": "month",
+                "in": "path",
+                "description": "Target month for the column.",
+                "required": true,
+                "schema": {
+                    "type": "integer",
+                    "maximum": 12,
+                    "minimum": 1
+                }
+            },
+            "CardIdParam": {
+                "name": "card",
+                "in": "path",
+                "description": "Identifier of the card.",
+                "required": true,
+                "schema": {
+                    "type": "integer",
+                    "minimum": 1
+                }
+            }
+        },
+        "securitySchemes": {
+            "SanctumToken": {
+                "type": "http",
+                "bearerFormat": "Sanctum",
+                "scheme": "bearer"
+            }
+        }
+    },
+    "tags": [
+        {
+            "name": "Auth",
+            "description": "Auth"
+        },
+        {
+            "name": "Cards",
+            "description": "Cards"
+        },
+        {
+            "name": "Columns",
+            "description": "Columns"
+        }
+    ]
+}


### PR DESCRIPTION
## Summary
- add L5-Swagger annotations for the Auth, Column, and Card controllers to mirror the existing OpenAPI paths
- port component schemas, parameters, responses, and security definitions into PHP annotations for L5-Swagger
- align the L5 Swagger configuration metadata and security defaults with the original roadmap.yaml specification

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68deca8fd4088333950ec72e686bd749